### PR TITLE
Use inria update sites for gecos

### DIFF
--- a/releng/alpha.language.target/alpha.language.target.target
+++ b/releng/alpha.language.target/alpha.language.target.target
@@ -4,18 +4,18 @@
 <!-- GeCoS -->
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.jnimapper.feature.feature.group" range="[1.2.0,2.0.0)"/>
-<repository location="https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-jnimapper/artifacts/"/>
+<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-jnimapper/artifacts/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.emf.feature.feature.group" range="[1.0.1,2.0.0)"/>
-<repository location="https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-emf/artifacts/"/>
+<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-emf/artifacts/"/>
 </location>
 
 <!-- ISL -->
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.isl.feature.feature.group" range="[1.8.1,2.0.0)"/>
 <unit id="fr.irisa.cairn.gecos.tools.barvinok.feature.feature.group" range="[1.8.1,2.0.0)"/>
-<repository location="https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/"/>
+<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/"/>
 </location>
 
 <!-- Eclipse/Xtend/Xtext -->
@@ -33,13 +33,13 @@
 <!-- TomMapping -->
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.tommapping.feature.feature.group" />
-<repository location="https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tommapping/artifacts/"/>
+<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tommapping/artifacts/"/>
 </location>
 
 <!-- Tom SDK -->
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.tomsdk.feature.feature.group"/>
-<repository location="https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tomsdk/artifacts/"/>
+<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tomsdk/artifacts/"/>
 </location>
 
 <!-- Groovy -->

--- a/scripts/resources/required-plugins.p2f
+++ b/scripts/resources/required-plugins.p2f
@@ -14,62 +14,62 @@
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.emf.feature.feature.group' name='GeCoS EMF Tools' version='1.0.1.202202021419'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-emf/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-emf/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.emf.feature.source.feature.group' name='GeCoS EMF Tools Developer Resources' version='1.0.1.202202021419'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-emf/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-emf/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.barvinok.feature.feature.group' name='GeCoS JNI Barvinok bindings' version='2.4.0.202202030940'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.barvinok.feature.source.feature.group' name='GeCoS JNI Barvinok bindings Developer Resources' version='2.4.0.202202030940'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.isl.feature.feature.group' name='GeCoS JNI ISL bindings' version='2.4.0.202202030940'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.isl.feature.source.feature.group' name='GeCoS JNI ISL bindings Developer Resources' version='2.4.0.202202030940'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.jnimapper.feature.feature.group' name='GeCoS JNI Mapper Tools' version='1.4.0.202202030956'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-jnimapper/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-jnimapper/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.jnimapper.feature.source.feature.group' name='GeCoS JNI Mapper Tools Developer Resources' version='1.4.0.202202030956'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-jnimapper/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-jnimapper/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.tommapping.feature.feature.group' name='GeCoS TOM Mapping Tools' version='1.0.1.202202021203'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tommapping/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tommapping/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.tommapping.feature.source.feature.group' name='GeCoS TOM Mapping Tools Developer Resources' version='1.0.1.202202021203'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tommapping/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tommapping/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.tomsdk.feature.feature.group' name='GeCoS TOM Tools' version='2.10.6.202202011652'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tomsdk/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tomsdk/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.tomsdk.feature.source.feature.group' name='GeCoS TOM Tools Developer Resources' version='2.10.6.202202011652'>
       <repositories size='1'>
-        <repository location='https://cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tomsdk/artifacts/'/>
+        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tomsdk/artifacts/'/>
       </repositories>
     </iu>
     <iu id='org.eclipse.egit.feature.group' name='Git integration for Eclipse' version='6.2.0.202206071550-r'>


### PR DESCRIPTION
A while back the gecos inria update sites had certificate issues. This caused our AlphaZ and alpha-language builds to break. I set up temporary mirror sites for gecos at CSU, and pointed our build scripts to those mirror sites. The certificate issues were fixed and the AlphaZ script pointers were updated (https://github.com/CSU-CS-Melange/AlphaZ/pull/8)  but I never updated the alpha-language scripts.

This PR updates the alpha-language build scripts to point back to the true inria gecos update sites.