### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
             })
             const keys_to_clear = [
               'cache-plugin',
-              'cache-eclipse-linux-x86',
-              'cache-eclipse-mac-x86'
             ]
             for (const cache of caches.data.actions_caches) {
               if (!keys_to_clear.includes(cache.key)) {
@@ -63,98 +61,9 @@ jobs:
       run: mvn clean package
 
 
-  build-bundle-linux-x86:
-    needs: build-plugin
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up java 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-
-    - name: Cache alpha plugin
-      id: cache-plugin
-      uses: actions/cache@v3
-      with:
-        path: ./releng/alpha.language.update/target/repository
-        key: cache-plugin
-
-    - name: Cache eclipse bundle linux-x86
-      id: cache-eclipse-linux-x86
-      uses: actions/cache@v3
-      with:
-        path: eclipse-bundle-linux-x86
-        key: cache-eclipse-linux-x86
-
-    - name: Set SHORT_SHA 
-      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-
-    - name: Build linux x86 bundle
-      run: ./scripts/make-bundle.sh linux-x86
-
-
-  build-bundle-mac-x86:
-    needs: build-plugin
-
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up java 11
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'zulu'
-        java-version: '11'
-
-    - name: Cache eclipse download
-      id: cache-eclipse-download-mac-x86
-      uses: actions/cache@v3
-      with:
-        path: eclipse-download-mac-x86
-        key: eclipse-download-mac-x86
-
-    - name: Cache alpha language plugin
-      id: cache-plugin
-      uses: actions/cache@v3
-      with:
-        path: ./releng/alpha.language.update/target/repository
-        key: cache-plugin
-
-    - name: Cache eclipse bundle mac-x86
-      id: cache-eclipse-mac-x86
-      uses: actions/cache@v3
-      with:
-        path: eclipse-bundle-mac-x86
-        key: cache-eclipse-mac-x86
-
-    - name: Set SHORT_SHA 
-      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-
-    - name: Build mac x86 bundle
-      env: 
-        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-      run: |
-        echo $BUILD_CERTIFICATE_BASE64 | base64 --decode > certificate.p12
-        security create-keychain -p $KEYCHAIN_PASSWORD build.keychain
-        security default-keychain -s build.keychain
-        security unlock-keychain -p $KEYCHAIN_PASSWORD build.keychain
-        security import certificate.p12 -k build.keychain -P $P12_PASSWORD -T /usr/bin/codesign
-        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PASSWORD build.keychain > /dev/null
-        ./scripts/make-bundle.sh mac-x86
-
-
   deploy:
     needs: 
     - build-plugin
-    - build-bundle-mac-x86
-    - build-bundle-linux-x86
 
     permissions:
       pages: write      # to deploy to Pages
@@ -176,31 +85,11 @@ jobs:
         path: ./releng/alpha.language.update/target/repository
         key: cache-plugin
 
-    - name: Cache eclipse bundle linux-x86
-      id: cache-eclipse-linux-x86
-      uses: actions/cache@v3
-      with:
-        path: eclipse-bundle-linux-x86
-        key: cache-eclipse-linux-x86
-
-    - name: Cache eclipse bundle mac-x86
-      id: cache-eclipse-mac-x86
-      uses: actions/cache@v3
-      with:
-        path: eclipse-bundle-mac-x86
-        key: cache-eclipse-mac-x86
-
     - name: Set SHORT_SHA 
       run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
 
     - name: Make downloads directory
       run: mkdir -p ./releng/alpha.language.update/target/repository/downloads
-
-    - name: Move linux-x86 to staging
-      run: mv eclipse-bundle-linux-x86/eclipse-alpha-language-linux-x86.tar.gz ./releng/alpha.language.update/target/repository/downloads/
-
-    - name: Move mac-x86 to staging
-      run: mv eclipse-bundle-mac-x86/eclipse-alpha-language-mac-x86.dmg ./releng/alpha.language.update/target/repository/downloads/
 
     - name: make update-site readme
       run: ./scripts/make-update-site-readme.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron:  '0 8 * * *'  # 3am MT, 9am UTC
 

--- a/scripts/make-update-site-readme.sh
+++ b/scripts/make-update-site-readme.sh
@@ -2,38 +2,11 @@
 
 readme_file=./releng/alpha.language.update/target/repository/README.md
 
-linux_x86_tar="eclipse-alpha-language-linux-x86.tar.gz"
-mac_x86_dmg="eclipse-alpha-language-mac-x86.dmg"
-#mac_aarch64_dmg="eclipse-alpha-language-mac-aarch64.dmg"
-
-base_url="https://csu-cs-melange.github.io/alpha-language"
-linux_x86_link="$base_url/downloads/$linux_x86_tar"
-mac_x86_link="$base_url/downloads/$mac_x86_dmg"
-#mac_aarch64_link="$base_url/downloads/$mac_aarch64_dmg"
-
-base_filepath="./releng/alpha.language.update/target"
-linux_x86_file="$base_filepath/downloads/$linux_x86_tar"
-mac_x86_file="$base_filepath/downloads/$mac_x86_dmg"
-#mac_aarch64_file="$base_filepath/downloads/$mac_aarch64_dmg"
-
-linux_x86_size=$(ls -lh $linux_x86_file | awk '{print  $5}')
-mac_x86_size=$(ls -lh $mac_x86_file | awk '{print  $5}')
-#mac_aarch64_size=$(ls -lh $mac_aarch64_file | awk '{print  $5}')
-
-linux_x86_sha=$(shasum $linux_x86_file | cut -d' ' -f1)
-mac_x86_sha=$(shasum $mac_x86_file | cut -d' ' -f1)
-#mac_aarch64_sha=$(shasum $mac_aarch64_file | cut -d' ' -f1)
-
 cat > $readme_file <<EOF
 This endpoint acts as the Eclipse update site used for the alpha-language repository. Last generated on \``date`\` from commit \``echo $GITHUB_SHA`\`.
 
 ## Eclipse bundles
 
-The following Eclipse bundles contain the AlphaZ plugin and all of its required dependencies.
-
-| Platform | Download | Size | SHA1 Checksum |
-| --- | --- | --- | --- |
-| Linux (x86_64) | [$linux_x86_tar]($linux_x86_link) | $linux_x86_size | $linux_x86_sha |
-| Mac (x86_64) | [$mac_x86_dmg]($mac_x86_link) | $mac_x86_size | $mac_x86_sha |
+$(tree ./releng/alpha.language.update/target/repository)
 
 EOF


### PR DESCRIPTION
Now we no longer build the eclipse bundles. This is hard to maintain longterm and more often than not, it has been easier to use the `scripts/make-bundle.sh` script to build the bundle locally when needed.