### PR TITLE
Simplification dev

### DIFF
--- a/bundles/alpha.model/model/alpha.xcore
+++ b/bundles/alpha.model/model/alpha.xcore
@@ -6,11 +6,12 @@ package alpha.model
 
 import alpha.model.exception.CyclicDefinitionException
 import alpha.model.util.AlphaUtil
-import fr.irisa.cairn.jnimap.isl.ISL_FORMAT
+import alpha.model.util.Show
+import fr.irisa.cairn.jnimap.isl.ISLMap
 import fr.irisa.cairn.jnimap.isl.ISLMultiAff
 import fr.irisa.cairn.jnimap.isl.ISLPWQPolynomial
-import fr.irisa.cairn.jnimap.isl.ISLMap
 import fr.irisa.cairn.jnimap.isl.ISLSet
+import fr.irisa.cairn.jnimap.isl.ISL_FORMAT
 import fr.irisa.cairn.jnimap.runtime.JNIObject
 import java.util.LinkedList
 import java.util.List
@@ -70,6 +71,12 @@ class AlphaNode {
 		
 		if (next === null) this
 		else (this.eContents.get(next) as AlphaNode).getNode(nodeID);
+	}
+
+	op String toString() {
+		if (this instanceof AlphaCompleteVisitable) {
+			return Show.print(this as AlphaCompleteVisitable)
+		}
 	}
 }
 

--- a/bundles/alpha.model/src/alpha/model/transformation/automation/SimplifyingReductionOptimalSimplificationAlgorithm.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/automation/SimplifyingReductionOptimalSimplificationAlgorithm.xtend
@@ -28,6 +28,7 @@ import java.util.Set
 import java.util.TreeSet
 import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.ecore.util.EcoreUtil
+import java.util.List
 
 /**
  * Implements Algorithm 2 in the Simplifying Reductions paper.
@@ -46,7 +47,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil
  */
 class SimplifyingReductionOptimalSimplificationAlgorithm {
 	
-	public static boolean DEBUG = true;
+	public static boolean DEBUG = false;
 	
 	private def debug(String content) {
 		if (DEBUG)
@@ -61,7 +62,7 @@ class SimplifyingReductionOptimalSimplificationAlgorithm {
 	protected final  AlphaRoot originalProgram;
 	protected final String systemName;
 	protected final  int systemBodyID;
-	protected AlphaRoot optimizedProgram;
+	protected List<AlphaRoot> optimizedPrograms;
 	
 	protected new (SystemBody body) {
 		originalProgram = AlphaUtil.getContainerRoot(body);
@@ -80,7 +81,7 @@ class SimplifyingReductionOptimalSimplificationAlgorithm {
 		val SROSA = new SimplifyingReductionOptimalSimplificationAlgorithm(body);
 		SROSA.run();
 		
-		return SROSA.optimizedProgram
+		return SROSA.optimizedPrograms
 	}
 	
 	/**
@@ -95,7 +96,8 @@ class SimplifyingReductionOptimalSimplificationAlgorithm {
 		exploreDPcontext(DPcontext)
 		
 		debug("After DP", DPcontext.state)
-		optimizedProgram = DPcontext.state.root
+		val ls = DPcontext.leafStates.toList
+		optimizedPrograms = DPcontext.leafStates.map[s|s.root]
 	}
 	
 	/**
@@ -155,6 +157,7 @@ class SimplifyingReductionOptimalSimplificationAlgorithm {
 		//The child context has all but the target equation put in the excluded list
 		//This is to explore only the equations added as a result of transforming the target equation
 		val childContext = context.copy
+		childContext.parent = context
 		childContext.excludedEquations.addAll(context.state.body.standardEquations.filter[e|e != eq].map[e|e.variable.name])
 		
 		while(!sideEffectFreeTransformations(childContext.state.body, eq.variable.name)) {}
@@ -190,30 +193,21 @@ class SimplifyingReductionOptimalSimplificationAlgorithm {
 				context.state = childContext.state;
 				context.excludeExploredEquationsInChildContext(childContext)
 			}
+			
 			context.markFinishedEquation(eq)
 			return
 		}
 		
 		//Otherwise apply the DP step and
-		val childContexts = new ArrayList<DynamicProgrammingContext>(candidates.size) 
 		for (step : candidates) {
 			debug(String.format("Applying Step: %s", step.description))
 			val child = childContext.copy
 			child.applyDPStep(step)
 			exploreDPcontext(child)
-			childContexts.add(child)
+			context.children.add(child)
 		}
 		
-		//use number of application of SR as the main cost metric, then number of equations as tie breaker
-		val bestChildState = childContexts.maxBy[c|c.state.nbSR*1000-c.state.body.standardEquations.size].state
-		
-		if (bestChildState.nbSR > context.state.nbSR) {
-			context.state = bestChildState;
-			context.excludeExploredEquationsInChildContext(childContext)
-			context.markFinishedEquation(eq)
-		} else {
-			context.markFinishedEquation(eq)
-		}
+		context.markFinishedEquation(eq)
 	}
 	
 	/**
@@ -288,9 +282,12 @@ class SimplifyingReductionOptimalSimplificationAlgorithm {
 		protected ProgramState state;
 		protected Set<String> excludedEquations = new TreeSet<String>();
 		protected Set<String> exploredEquations = new TreeSet<String>();
+		protected DynamicProgrammingContext parent;
+		protected LinkedList<DynamicProgrammingContext> children;
 		
 		new (ProgramState state) {
 			this.state = state;
+			this.children = new LinkedList<DynamicProgrammingContext>
 		}
 		
 		protected def markFinishedEquation(String eqName) {
@@ -310,6 +307,24 @@ class SimplifyingReductionOptimalSimplificationAlgorithm {
 				copy.excludedEquations.add(ee)
 			
 			return copy
+		}
+		
+		def isLeaf() {
+			children.empty
+		}
+	
+		def List<ProgramState> leafStates() {
+			if (isLeaf) {
+				return #[state]
+			}
+			val states = new ArrayList<ProgramState>
+			children.forEach[c|states.addAll(c.leafStates)]
+			return states
+		}
+	
+		def addChild(DynamicProgrammingContext child) {
+			child.parent = this
+			children.add(child)
 		}
 	}
 	


### PR DESCRIPTION
This changes the optimal simplification implementation so that it explores and returns all possible simplifications.

For example, given this input:
```
affine example [N] -> {  : N >= 11 }
	inputs
		X : {[i]: 0 <= i <= 2N }
	outputs
		Y : {[i]: 0 <= i <= N }
	when {  : N >= 11 } let
		Y = reduce(+, (i,j->i), {[i, j]: 0 <= j <= 2i } : (i,j->j)@X);
.
```
Now both possible simplifications are returned:
```
affine example [N] -> {  : N >= 11 }
	inputs
		X : {[i]: 0 <= i <= 2N }
	outputs
		Y : {[i]: 0 <= i <= N }
	locals
		Y_add : {[i0]: 0 <= i0 <= N }
	when {  : N >= 11 } let
		Y = case  {
			{[i0]: i0 = 0 } : Y_add;
			(Y_add + (i->i-1)@Y);
		};
		
		Y_add = reduce(+, (i,j->i), {[i, j]: i <= N and j >= -1 + 2i and 0 <= j <= 2i } : (i,j->j)@X);
.

affine example [N] -> {  : N >= 11 }
	inputs
		X : {[i]: 0 <= i <= 2N }
	outputs
		Y : {[i]: 0 <= i <= N }
	locals
		Y_add : {[i0]: i0 = N }
		Y_sub : {[i0]: 0 <= i0 < N }
	when {  : N >= 11 } let
		Y = case  {
			Y_add;
			((i->i+1)@Y - Y_sub);
		};
		
		Y_add = reduce(+, (i,j->i), {[i, j]: i = N and 0 <= j <= 2N } : (i,j->j)@X);
		
		Y_sub = reduce(+, (i,j->i), {[i, j]: 0 <= i < N and 2i < j <= 2 + 2i } : (i,j->j)@X);
.
```









