### PR TITLE
Fix face lattice test domain comparison

### DIFF
--- a/tests/alpha.model.tests/src/alpha/model/tests/util/FaceLatticeTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/util/FaceLatticeTest.xtend
@@ -10,6 +10,7 @@ import java.util.List
 import org.junit.Test
 
 import static org.junit.Assert.*
+import fr.irisa.cairn.jnimap.isl.ISLDimType
 
 class FaceLatticeTest {
 	////////////////////////////////////////////////////////////
@@ -128,7 +129,9 @@ class FaceLatticeTest {
 	
 	/** Determines if two vertices are equal. */
 	def private static areVerticesEqual(ISLVertex v1, ISLVertex v2) {
-		val domainsEqual = v1.domain.isEqual(v2.domain)
+		val d1NoParamDivs = v1.domain.removeDivsInvolvingDims(ISLDimType.isl_dim_param, 0, v1.domain.space.nbParams)
+		val d2NoParamDivs = v2.domain.removeDivsInvolvingDims(ISLDimType.isl_dim_param, 0, v2.domain.space.nbParams)
+		val domainsEqual = d1NoParamDivs.isEqual(d2NoParamDivs)
 		val exprsEqual = v1.expr.isPlainEqual(v2.expr)
 		return domainsEqual && exprsEqual
 	}
@@ -412,6 +415,11 @@ class FaceLatticeTest {
 		assertFalse(lattice.isSimplicial)
 		assertFaceCounts(lattice, 0, 1)
 		assertRootHasChildren(lattice)  // Don't include any children, as the root has none.
+	}
+	
+	@Test
+	def testConstruction_1() {
+		val lattice = makeLattice("[N]->{[i,j,k] : 0<=i,j,k and N<2i+j+3k and i+j+k<2N+3}")
 	}
 	
 	// The following partially completed test does not currently work.

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/util/FaceLatticeTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/util/FaceLatticeTest.java
@@ -4,6 +4,7 @@ import alpha.model.util.FaceLattice;
 import alpha.model.util.Facet;
 import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
 import fr.irisa.cairn.jnimap.isl.ISLContext;
+import fr.irisa.cairn.jnimap.isl.ISLDimType;
 import fr.irisa.cairn.jnimap.isl.ISLVertex;
 import fr.irisa.cairn.jnimap.isl.ISLVertices;
 import java.util.ArrayList;
@@ -150,7 +151,9 @@ public class FaceLatticeTest {
    * Determines if two vertices are equal.
    */
   private static boolean areVerticesEqual(final ISLVertex v1, final ISLVertex v2) {
-    final boolean domainsEqual = v1.getDomain().isEqual(v2.getDomain());
+    final ISLBasicSet d1NoParamDivs = v1.getDomain().removeDivsInvolvingDims(ISLDimType.isl_dim_param, 0, v1.getDomain().getSpace().getNbParams());
+    final ISLBasicSet d2NoParamDivs = v2.getDomain().removeDivsInvolvingDims(ISLDimType.isl_dim_param, 0, v2.getDomain().getSpace().getNbParams());
+    final boolean domainsEqual = d1NoParamDivs.isEqual(d2NoParamDivs);
     final boolean exprsEqual = v1.getExpr().isPlainEqual(v2.getExpr());
     return (domainsEqual && exprsEqual);
   }
@@ -416,5 +419,10 @@ public class FaceLatticeTest {
     Assert.assertFalse(lattice.isSimplicial());
     FaceLatticeTest.assertFaceCounts(lattice, 0, 1);
     FaceLatticeTest.assertRootHasChildren(lattice);
+  }
+
+  @Test
+  public void testConstruction_1() {
+    final FaceLattice lattice = FaceLatticeTest.makeLattice("[N]->{[i,j,k] : 0<=i,j,k and N<2i+j+3k and i+j+k<2N+3}");
   }
 }


### PR DESCRIPTION
Here is an edge case where the `makeLattice` function fails:
```
[N]->{[i,j,k] : 0<=i,j,k and N<2i+j+3k and i+j+k<2N+3}
``` 

The problem is that div constraints involving parameters are retained by the lattice vertex representation, but not by isl. So the check that compares them fails.

One of the vertices has the same expression values:
```
[N] -> { [(1 + N)/2, (0), (0)] }    <— lattice representation
[N] -> { [(1 + N)/2, (0), (0)] }    <— isl representation
```
but different domains:
```
[N] -> {  : (1 + N) mod 2 = 0 and N >= -1 }       <— lattice representation
[N] -> {  : N >= -1 }                             <— isl representation
```

We should ignore any div constraints involving parameters at least in alpha.model.test. I’m not sure if we need to (or should) change the `toBasicSet` method in alpha.model.util.Facet to also drop divs involving params. We’d have to be careful to try to differentiate between divs introduced artificially by the lattice construction and divs that the user may have specified in the input program.

Minimally, we can probably ignore these in the tests.