### PR TITLE
Also ensuring any ISLMultiAff domain and ranges are named

### DIFF
--- a/bundles/alpha.model/model/alpha.xcore
+++ b/bundles/alpha.model/model/alpha.xcore
@@ -1108,7 +1108,7 @@ class JNIFunction extends CalculatorExpression {
 	JNIISLMultiAff z__internal_cache_islMAff
 	
 	op JNIISLMultiAff getISLMultiAff() { if (z__internal_cache_islMAff !== null) z__internal_cache_islMAff.copy else null }
-	op void setISLMultiAff(JNIISLMultiAff islMAff) { z__internal_cache_islMAff = islMAff }
+	op void setISLMultiAff(JNIISLMultiAff islMAff) { z__internal_cache_islMAff = islMAff.ensureDomainAndRangeAreNamed }
 	
 	op POLY_OBJECT_TYPE getType() { if (z__internal_cache_islMAff !== null) POLY_OBJECT_TYPE::FUNCTION else null }
 	op JNIObject getISLObject() { ISLMultiAff }
@@ -1119,6 +1119,30 @@ class JNIFunction extends CalculatorExpression {
 	
 	op String plainToString() {
 		alphaFunction.plainToString()
+	}
+	
+	/**
+	 * Sometimes the ISLMutliAff does not have any input or output 
+	 * names (i.e., is null). In this case, issues may arise when 
+	 * trying to use the domain and range. To counteract this, if 
+	 * there is not a name for every index, then replace all the 
+	 * names with the default index names.
+	 */
+	op JNIISLMultiAff ensureDomainAndRangeAreNamed(JNIISLMultiAff maff) {
+		val inputNames = maff.space.inputNames
+		val inputCount = maff.space.nbInputs
+		val outputNames = maff.space.outputNames
+		val outputCount = maff.space.nbOutputs
+		var retMaff = maff
+		
+		if ((inputNames === null) || (inputNames.size != inputCount)) {
+			retMaff = AlphaUtil.renameInputs(maff)
+		}
+		if ((outputNames === null) || (outputNames.size != outputCount)) {
+			retMaff = AlphaUtil.renameOutputs(maff)
+		}	
+		
+		return retMaff
 	}
 }
 

--- a/bundles/alpha.model/src-gen/alpha/model/JNIFunction.java
+++ b/bundles/alpha.model/src-gen/alpha/model/JNIFunction.java
@@ -116,4 +116,20 @@ public interface JNIFunction extends CalculatorExpression {
 	 */
 	String plainToString();
 
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * *
+	 * Sometimes the ISLMutliAff does not have any input or output
+	 * names (i.e., is null). In this case, issues may arise when
+	 * trying to use the domain and range. To counteract this, if
+	 * there is not a name for every index, then replace all the
+	 * names with the default index names.
+	 * <!-- end-model-doc -->
+	 * @model dataType="alpha.model.JNIISLMultiAff" unique="false" maffDataType="alpha.model.JNIISLMultiAff" maffUnique="false"
+	 * @generated
+	 */
+	ISLMultiAff ensureDomainAndRangeAreNamed(ISLMultiAff maff);
+
 } // JNIFunction

--- a/bundles/alpha.model/src-gen/alpha/model/impl/JNIFunctionImpl.java
+++ b/bundles/alpha.model/src-gen/alpha/model/impl/JNIFunctionImpl.java
@@ -8,9 +8,13 @@ import alpha.model.JNIFunction;
 import alpha.model.ModelPackage;
 import alpha.model.POLY_OBJECT_TYPE;
 
+import alpha.model.util.AlphaUtil;
+
 import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
 
 import fr.irisa.cairn.jnimap.runtime.JNIObject;
+
+import java.util.List;
 
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
@@ -172,7 +176,7 @@ public class JNIFunctionImpl extends CalculatorExpressionImpl implements JNIFunc
 	 * @generated
 	 */
 	public void setISLMultiAff(final ISLMultiAff islMAff) {
-		this.setZ__internal_cache_islMAff(islMAff);
+		this.setZ__internal_cache_islMAff(this.ensureDomainAndRangeAreNamed(islMAff));
 	}
 
 	/**
@@ -218,6 +222,26 @@ public class JNIFunctionImpl extends CalculatorExpressionImpl implements JNIFunc
 	 */
 	public String plainToString() {
 		return this.getAlphaFunction().plainToString();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public ISLMultiAff ensureDomainAndRangeAreNamed(final ISLMultiAff maff) {
+		final List<String> inputNames = maff.getSpace().getInputNames();
+		final int inputCount = maff.getSpace().getNbInputs();
+		final List<String> outputNames = maff.getSpace().getOutputNames();
+		final int outputCount = maff.getSpace().getNbOutputs();
+		ISLMultiAff retMaff = maff;
+		if (((inputNames == null) || (inputNames.size() != inputCount))) {
+			retMaff = AlphaUtil.renameInputs(maff);
+		}
+		if (((outputNames == null) || (outputNames.size() != outputCount))) {
+			retMaff = AlphaUtil.renameOutputs(maff);
+		}
+		return retMaff;
 	}
 
 	/**

--- a/bundles/alpha.model/src-gen/alpha/model/impl/ModelPackageImpl.java
+++ b/bundles/alpha.model/src-gen/alpha/model/impl/ModelPackageImpl.java
@@ -815,6 +815,7 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage {
 	private ModelPackageImpl() {
 		super(eNS_URI, ModelFactory.eINSTANCE);
 	}
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -3918,6 +3919,9 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage {
 		op = addEOperation(alphaExpressionEClass, this.getAlphaExpression(), "getExpression", 0, 1, !IS_UNIQUE, IS_ORDERED);
 		addEParameter(op, this.getIntegerQueue(), "exprID", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
+		op = addEOperation(alphaExpressionEClass, this.getJNIISLSet(), "ensureDomainIsNamed", 0, 1, !IS_UNIQUE, IS_ORDERED);
+		addEParameter(op, this.getJNIISLSet(), "dom", 0, 1, !IS_UNIQUE, IS_ORDERED);
+
 		initEClass(restrictExpressionEClass, RestrictExpression.class, "RestrictExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getRestrictExpression_DomainExpr(), this.getCalculatorExpression(), null, "domainExpr", null, 0, 1, RestrictExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getRestrictExpression_Expr(), this.getAlphaExpression(), null, "expr", null, 0, 1, RestrictExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -4226,6 +4230,9 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage {
 		addEParameter(op, this.getCalculatorExpressionVisitor(), "visitor", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		addEOperation(jniFunctionEClass, this.getString(), "plainToString", 0, 1, !IS_UNIQUE, IS_ORDERED);
+
+		op = addEOperation(jniFunctionEClass, this.getJNIISLMultiAff(), "ensureDomainAndRangeAreNamed", 0, 1, !IS_UNIQUE, IS_ORDERED);
+		addEParameter(op, this.getJNIISLMultiAff(), "maff", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEClass(jniFunctionInArrayNotationEClass, JNIFunctionInArrayNotation.class, "JNIFunctionInArrayNotation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getJNIFunctionInArrayNotation_ArrayNotation(), this.getString(), "arrayNotation", null, 0, -1, JNIFunctionInArrayNotation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
@@ -312,6 +312,30 @@ class AlphaUtil {
 			
 		return res
 	}
+	static def renameInputs(ISLMultiAff maff) {
+		return renameInputs(maff, maff.defaultInputNames)
+	}
+	static def renameOutputs(ISLMultiAff maff) {
+		return renameOutputs(maff, maff.defaultOutputNames)
+	}
+	static def renameInputs(ISLMultiAff maff, List<String> names) {
+		val nbDims = maff.getNbInputs
+		if (nbDims > names.length) {
+			println()
+			throw new RuntimeException("Need n or more index names to rename n-d space.")
+		}
+		return (0..<nbDims).fold(maff, [_maff, dim | _maff.setDimName(ISLDimType.isl_dim_in,  dim, names.get(dim))])
+	}
+	static def renameOutputs(ISLMultiAff maff, List<String> names) {
+		val nbDims = maff.getNbOutputs
+		if (nbDims > names.length) {
+			println()
+			throw new RuntimeException("Need n or more index names to rename n-d space.")
+		}
+		
+		return (0..<nbDims).fold(maff, [_maff, dim | _maff.setDimName(ISLDimType.isl_dim_out,  dim, names.get(dim))])
+	}
+	
 	
 	static def defaultDimNames(int n) {
 		defaultDimNames(0, n)
@@ -323,6 +347,14 @@ class AlphaUtil {
 	
 	static def defaultDimNames(ISLSet set) {
 		defaultDimNames(set.nbIndices)
+	}
+	
+	static def defaultInputNames(ISLMultiAff maff) {
+		defaultDimNames(maff.nbInputs).map[s | '_' + s]
+	}
+	
+	static def defaultOutputNames(ISLMultiAff maff) {
+		defaultDimNames(maff.nbOutputs)
 	}
 	
 	static def parseIntArray(String intVecStr) {

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
@@ -39,6 +39,7 @@ import org.eclipse.xtext.xbase.lib.ExclusiveRange;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.Functions.Function2;
 import org.eclipse.xtext.xbase.lib.Functions.Function3;
+import org.eclipse.xtext.xbase.lib.InputOutput;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
@@ -414,6 +415,42 @@ public class AlphaUtil {
     return res;
   }
 
+  public static ISLMultiAff renameInputs(final ISLMultiAff maff) {
+    return AlphaUtil.renameInputs(maff, AlphaUtil.defaultInputNames(maff));
+  }
+
+  public static ISLMultiAff renameOutputs(final ISLMultiAff maff) {
+    return AlphaUtil.renameOutputs(maff, AlphaUtil.defaultOutputNames(maff));
+  }
+
+  public static ISLMultiAff renameInputs(final ISLMultiAff maff, final List<String> names) {
+    final int nbDims = maff.getNbInputs();
+    int _length = ((Object[])Conversions.unwrapArray(names, Object.class)).length;
+    boolean _greaterThan = (nbDims > _length);
+    if (_greaterThan) {
+      InputOutput.println();
+      throw new RuntimeException("Need n or more index names to rename n-d space.");
+    }
+    final Function2<ISLMultiAff, Integer, ISLMultiAff> _function = (ISLMultiAff _maff, Integer dim) -> {
+      return _maff.setDimName(ISLDimType.isl_dim_in, (dim).intValue(), names.get((dim).intValue()));
+    };
+    return IterableExtensions.<Integer, ISLMultiAff>fold(new ExclusiveRange(0, nbDims, true), maff, _function);
+  }
+
+  public static ISLMultiAff renameOutputs(final ISLMultiAff maff, final List<String> names) {
+    final int nbDims = maff.getNbOutputs();
+    int _length = ((Object[])Conversions.unwrapArray(names, Object.class)).length;
+    boolean _greaterThan = (nbDims > _length);
+    if (_greaterThan) {
+      InputOutput.println();
+      throw new RuntimeException("Need n or more index names to rename n-d space.");
+    }
+    final Function2<ISLMultiAff, Integer, ISLMultiAff> _function = (ISLMultiAff _maff, Integer dim) -> {
+      return _maff.setDimName(ISLDimType.isl_dim_out, (dim).intValue(), names.get((dim).intValue()));
+    };
+    return IterableExtensions.<Integer, ISLMultiAff>fold(new ExclusiveRange(0, nbDims, true), maff, _function);
+  }
+
   public static List<String> defaultDimNames(final int n) {
     return AlphaUtil.defaultDimNames(0, n);
   }
@@ -427,6 +464,17 @@ public class AlphaUtil {
 
   public static List<String> defaultDimNames(final ISLSet set) {
     return AlphaUtil.defaultDimNames(set.getNbIndices());
+  }
+
+  public static List<String> defaultInputNames(final ISLMultiAff maff) {
+    final Function1<String, String> _function = (String s) -> {
+      return ("_" + s);
+    };
+    return ListExtensions.<String, String>map(AlphaUtil.defaultDimNames(maff.getNbInputs()), _function);
+  }
+
+  public static List<String> defaultOutputNames(final ISLMultiAff maff) {
+    return AlphaUtil.defaultDimNames(maff.getNbOutputs());
   }
 
   public static int[] parseIntArray(final String intVecStr) {


### PR DESCRIPTION
PR #12 ensures that all context and expression domains objs (ISLSet) have named indices.

This does the same thing but for functions (ISLMultiAff). 