### PR TITLE
Compute the dimensionality using Theorem 1 from GR06

### DIFF
--- a/bundles/alpha.model/src/alpha/model/util/FaceLattice.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/FaceLattice.xtend
@@ -2,9 +2,9 @@ package alpha.model.util
 
 import fr.irisa.cairn.jnimap.isl.ISLBasicSet
 import java.util.ArrayList
+import java.util.Collection
 import java.util.LinkedList
 import org.eclipse.xtend.lib.annotations.Accessors
-import java.util.Collection
 
 /**
  * Constructs the face lattice of a given <code>ISLBasicSet</code>.

--- a/bundles/alpha.model/src/alpha/model/util/ISLUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/ISLUtil.xtend
@@ -1,0 +1,67 @@
+package alpha.model.util
+
+import fr.irisa.cairn.jnimap.isl.ISLAff
+import fr.irisa.cairn.jnimap.isl.ISLBasicMap
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet
+import fr.irisa.cairn.jnimap.isl.ISLConstraint
+import fr.irisa.cairn.jnimap.isl.ISLContext
+import fr.irisa.cairn.jnimap.isl.ISLDimType
+import fr.irisa.cairn.jnimap.isl.ISLMatrix
+import fr.irisa.cairn.jnimap.isl.ISLSet
+
+import static extension alpha.model.matrix.MatrixOperations.scalarMultiplication
+import static extension alpha.model.matrix.MatrixOperations.transpose
+import static extension alpha.model.util.DomainOperations.*
+
+class ISLUtil {
+	
+	/** Creates an ISLBasicSet from a string */
+	def static toISLBasicSet(String descriptor) {
+		ISLBasicSet.buildFromString(ISLContext.instance, descriptor)
+	}
+	
+	/** Creates an ISLSet from a string */
+	def static toISLSet(String descriptor) {
+		ISLSet.buildFromString(ISLContext.instance, descriptor)
+	}
+	
+	/** Creates an ISLBasicMap from a string */
+	def static toISLBasicMap(String descriptor) {
+		ISLBasicMap.buildFromString(ISLContext.instance, descriptor)
+	}
+	
+	/** Creates an ISLBasicSet from a string */
+	def static toISLAff(String descriptor) {
+		ISLAff.buildFromString(ISLContext.instance, descriptor)
+	}
+	
+	/** Transposes an ISLMatrix */
+	def static transpose(ISLMatrix matrix) {
+		ISLMatrix.buildFromLongMatrix(matrix.toLongMatrix.transpose)
+	}
+	
+	/** Returns the integer point closest to the origin in set without parameter context */
+	def static long[] integerPointClosestToOrigin(ISLBasicSet set) {
+		set.copy.samplePoint.coordinates.subList(set.nbParams, set.nbParams + set.nbIndices)
+	}
+	
+	def static isTrivial(ISLBasicSet set) {
+		var origin = ISLBasicSet.buildUniverse(set.space.copy)
+		for (i : 0..<set.space.nbIndices) {
+			val aff = ISLAff.buildZero(set.space.copy.toLocalSpace)
+			origin = origin.addConstraint(aff.setCoefficient(ISLDimType.isl_dim_in, i, 1).toEqualityConstraint)
+		}
+		
+		set.copy.toSet.subtract(origin.toSet).isEmpty
+	}
+	
+	def static isTrivial(ISLSet set) {
+		var origin = ISLSet.buildUniverse(set.space.copy)
+		for (i : 0..<set.space.nbIndices) {
+			val aff = ISLAff.buildZero(set.space.copy.toLocalSpace)
+			origin = origin.addConstraint(aff.setCoefficient(ISLDimType.isl_dim_in, i, 1).toEqualityConstraint)
+		}
+		
+		set.subtract(origin).isEmpty
+	}
+}

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/Facet.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/Facet.java
@@ -135,7 +135,7 @@ public class Facet {
       this.parameterEqualityCount = Facet.countParameterConstraints(this.equalities, this.indexCount);
       this.parameterInequalities = Facet.getInequalities(basicSetNoRedundancies, this.indexCount, false);
       this.saturatedInequalityIndices = saturatedInequalityIndices;
-      this.dimensionality = Facet.dimensionality(this.thickEqualities, this.equalities, this.indexCount);
+      this.dimensionality = ISLUtil.dimensionality(basicSet);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -291,24 +291,6 @@ public class Facet {
       return Boolean.valueOf(Facet.constraintInvolvesIndex(matrix, (row).intValue(), indexCount));
     };
     return IterableExtensions.size(IterableExtensions.<Integer>reject(new ExclusiveRange(0, _nbRows, true), _function));
-  }
-
-  /**
-   * Returns the dimensionality of a set using the effectively saturated constraints,
-   * equality constraints and number of index variables.
-   */
-  private static int dimensionality(final ISLMatrix thickEqualities, final ISLMatrix equalities, final int indexCount) {
-    int _nbRows = equalities.getNbRows();
-    final Function1<Integer, Boolean> _function = (Integer row) -> {
-      return Boolean.valueOf(Facet.constraintInvolvesIndex(equalities, (row).intValue(), indexCount));
-    };
-    final Function2<ISLMatrix, Integer, ISLMatrix> _function_1 = (ISLMatrix mat, Integer row) -> {
-      return mat.dropRows((row).intValue(), 1);
-    };
-    final int linearlyIndependentIndexEqualities = IterableExtensions.<Integer, ISLMatrix>fold(IterableExtensions.<Integer>reject(new ExclusiveRange(_nbRows, 0, false), _function), equalities.copy(), _function_1).rank();
-    int _nbRows_1 = thickEqualities.getNbRows();
-    final int numThickEqualities = (_nbRows_1 / 2);
-    return ((indexCount - linearlyIndependentIndexEqualities) - numThickEqualities);
   }
 
   /**

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/ISLUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/ISLUtil.java
@@ -1,0 +1,97 @@
+package alpha.model.util;
+
+import alpha.model.matrix.MatrixOperations;
+import fr.irisa.cairn.jnimap.isl.ISLAff;
+import fr.irisa.cairn.jnimap.isl.ISLBasicMap;
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
+import fr.irisa.cairn.jnimap.isl.ISLContext;
+import fr.irisa.cairn.jnimap.isl.ISLDimType;
+import fr.irisa.cairn.jnimap.isl.ISLMatrix;
+import fr.irisa.cairn.jnimap.isl.ISLSet;
+import java.util.List;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.ExclusiveRange;
+
+@SuppressWarnings("all")
+public class ISLUtil {
+  /**
+   * Creates an ISLBasicSet from a string
+   */
+  public static ISLBasicSet toISLBasicSet(final String descriptor) {
+    return ISLBasicSet.buildFromString(ISLContext.getInstance(), descriptor);
+  }
+
+  /**
+   * Creates an ISLSet from a string
+   */
+  public static ISLSet toISLSet(final String descriptor) {
+    return ISLSet.buildFromString(ISLContext.getInstance(), descriptor);
+  }
+
+  /**
+   * Creates an ISLBasicMap from a string
+   */
+  public static ISLBasicMap toISLBasicMap(final String descriptor) {
+    return ISLBasicMap.buildFromString(ISLContext.getInstance(), descriptor);
+  }
+
+  /**
+   * Creates an ISLBasicSet from a string
+   */
+  public static ISLAff toISLAff(final String descriptor) {
+    return ISLAff.buildFromString(ISLContext.getInstance(), descriptor);
+  }
+
+  /**
+   * Transposes an ISLMatrix
+   */
+  public static ISLMatrix transpose(final ISLMatrix matrix) {
+    return ISLMatrix.buildFromLongMatrix(MatrixOperations.transpose(matrix.toLongMatrix()));
+  }
+
+  /**
+   * Returns the integer point closest to the origin in set without parameter context
+   */
+  public static long[] integerPointClosestToOrigin(final ISLBasicSet set) {
+    List<Long> _coordinates = set.copy().samplePoint().getCoordinates();
+    int _nbParams = set.getNbParams();
+    int _nbParams_1 = set.getNbParams();
+    int _nbIndices = set.getNbIndices();
+    int _plus = (_nbParams_1 + _nbIndices);
+    return ((long[])Conversions.unwrapArray(_coordinates.subList(_nbParams, _plus), long.class));
+  }
+
+  public static boolean isTrivial(final ISLBasicSet set) {
+    boolean _xblockexpression = false;
+    {
+      ISLBasicSet origin = ISLBasicSet.buildUniverse(set.getSpace().copy());
+      int _nbIndices = set.getSpace().getNbIndices();
+      ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, _nbIndices, true);
+      for (final Integer i : _doubleDotLessThan) {
+        {
+          final ISLAff aff = ISLAff.buildZero(set.getSpace().copy().toLocalSpace());
+          origin = origin.addConstraint(aff.setCoefficient(ISLDimType.isl_dim_in, (i).intValue(), 1).toEqualityConstraint());
+        }
+      }
+      _xblockexpression = set.copy().toSet().subtract(origin.toSet()).isEmpty();
+    }
+    return _xblockexpression;
+  }
+
+  public static boolean isTrivial(final ISLSet set) {
+    boolean _xblockexpression = false;
+    {
+      ISLSet origin = ISLSet.buildUniverse(set.getSpace().copy());
+      int _nbIndices = set.getSpace().getNbIndices();
+      ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, _nbIndices, true);
+      for (final Integer i : _doubleDotLessThan) {
+        {
+          final ISLAff aff = ISLAff.buildZero(set.getSpace().copy().toLocalSpace());
+          origin = origin.addConstraint(aff.setCoefficient(ISLDimType.isl_dim_in, (i).intValue(), 1).toEqualityConstraint());
+        }
+      }
+      _xblockexpression = set.subtract(origin).isEmpty();
+    }
+    return _xblockexpression;
+  }
+}

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/ISLUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/ISLUtil.java
@@ -1,16 +1,23 @@
 package alpha.model.util;
 
 import alpha.model.matrix.MatrixOperations;
+import com.google.common.collect.Iterables;
 import fr.irisa.cairn.jnimap.isl.ISLAff;
 import fr.irisa.cairn.jnimap.isl.ISLBasicMap;
 import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
+import fr.irisa.cairn.jnimap.isl.ISLConstraint;
 import fr.irisa.cairn.jnimap.isl.ISLContext;
 import fr.irisa.cairn.jnimap.isl.ISLDimType;
 import fr.irisa.cairn.jnimap.isl.ISLMatrix;
 import fr.irisa.cairn.jnimap.isl.ISLSet;
+import java.util.HashSet;
 import java.util.List;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.ExclusiveRange;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
 
 @SuppressWarnings("all")
 public class ISLUtil {
@@ -93,5 +100,59 @@ public class ISLUtil {
       _xblockexpression = set.subtract(origin).isEmpty();
     }
     return _xblockexpression;
+  }
+
+  /**
+   * Returns true if c is effectively saturated per Theorem 1 in GR06, and false otherwise
+   */
+  public static boolean isEffectivelySaturated(final ISLConstraint c, final ISLBasicSet P) {
+    boolean _isEquality = c.isEquality();
+    if (_isEquality) {
+      return true;
+    }
+    final Function1<ISLConstraint, Long> _function = (ISLConstraint it) -> {
+      return Long.valueOf(it.getConstant());
+    };
+    final int tau = IterableExtensions.<Long>max(ListExtensions.<ISLConstraint, Long>map(P.getConstraints(), _function)).intValue();
+    ISLAff _negate = c.getAff().negate();
+    int _intValue = Long.valueOf(c.getConstant()).intValue();
+    int _plus = (_intValue + tau);
+    final ISLBasicSet cPrime = _negate.setConstant(_plus).toInequalityConstraint().toBasicSet();
+    return cPrime.intersect(P.copy()).isEqual(P);
+  }
+
+  /**
+   * Given the ISLAff of an effectively saturated constraint return a long[] of the linear part
+   * the first non-zero value is guaranteed to be positive
+   */
+  public static long[] toLinearUnitVector(final ISLAff aff) {
+    int _nbParams = aff.getNbParams();
+    int _nbInputs = aff.getNbInputs();
+    final int constantCol = (_nbParams + _nbInputs);
+    final long[] vec = DomainOperations.toISLEqualityMatrix(aff.toEqualityConstraint().toBasicSet()).dropCols(constantCol, 1).toLongMatrix()[0];
+    final Function1<Long, Boolean> _function = (Long v) -> {
+      return Boolean.valueOf(((v).longValue() == 0));
+    };
+    Long _get = IterableExtensions.<Long>toList(IterableExtensions.<Long>reject(((Iterable<Long>)Conversions.doWrapArray(vec)), _function)).get(0);
+    boolean _lessThan = ((_get).longValue() < 0);
+    if (_lessThan) {
+      return MatrixOperations.scalarMultiplication(vec, (-1));
+    }
+    return vec;
+  }
+
+  public static int dimensionality(final ISLBasicSet set) {
+    final HashSet<String> effectivelySaturatedConstraints = CollectionLiterals.<String>newHashSet();
+    final Function1<ISLConstraint, Boolean> _function = (ISLConstraint c) -> {
+      return Boolean.valueOf(ISLUtil.isEffectivelySaturated(c, set));
+    };
+    final Function1<ISLConstraint, String> _function_1 = (ISLConstraint it) -> {
+      return ((List<Long>)Conversions.doWrapArray(ISLUtil.toLinearUnitVector(it.getAff()))).toString();
+    };
+    Iterables.<String>addAll(effectivelySaturatedConstraints, 
+      IterableExtensions.<ISLConstraint, String>map(IterableExtensions.<ISLConstraint>filter(set.getConstraints(), _function), _function_1));
+    int _nbIndices = set.getNbIndices();
+    int _size = effectivelySaturatedConstraints.size();
+    return (_nbIndices - _size);
   }
 }

--- a/tests/alpha.model.tests/src/alpha/model/tests/util/FaceLatticeTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/util/FaceLatticeTest.xtend
@@ -11,6 +11,8 @@ import org.junit.Test
 
 import static org.junit.Assert.*
 
+import static extension alpha.model.util.ISLUtil.*
+
 class FaceLatticeTest {
 	////////////////////////////////////////////////////////////
 	// Assertions for Specific Aspects of the Face Lattice
@@ -486,4 +488,12 @@ class FaceLatticeTest {
 		facets.forEach[f | assertTrue(f.hasThickFaces)]
 	}
 	
+	@Test
+	def testThickEquality_3() {
+		val set1 = "[N]->{[i,j,k,l]: N>=11 and i<=3 and 2+i<=j<=N and i<=k<=-2+2i and -2+i+j<=l<i+j}".toISLBasicSet
+		val set2 = "[N]->{[i,j]: N>=11 and 0<=i<=N and i<j and j<i+5}".toISLBasicSet
+		
+		assertEquals(set1.dimensionality, 1)
+		assertEquals(set2.dimensionality, 1)
+	}
 }

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/util/FaceLatticeTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/util/FaceLatticeTest.java
@@ -2,6 +2,7 @@ package alpha.model.tests.util;
 
 import alpha.model.util.FaceLattice;
 import alpha.model.util.Facet;
+import alpha.model.util.ISLUtil;
 import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
 import fr.irisa.cairn.jnimap.isl.ISLContext;
 import fr.irisa.cairn.jnimap.isl.ISLVertex;
@@ -486,5 +487,13 @@ public class FaceLatticeTest {
       Assert.assertTrue(f.hasThickFaces());
     };
     facets.forEach(_function);
+  }
+
+  @Test
+  public void testThickEquality_3() {
+    final ISLBasicSet set1 = ISLUtil.toISLBasicSet("[N]->{[i,j,k,l]: N>=11 and i<=3 and 2+i<=j<=N and i<=k<=-2+2i and -2+i+j<=l<i+j}");
+    final ISLBasicSet set2 = ISLUtil.toISLBasicSet("[N]->{[i,j]: N>=11 and 0<=i<=N and i<j and j<i+5}");
+    Assert.assertEquals(ISLUtil.dimensionality(set1), 1);
+    Assert.assertEquals(ISLUtil.dimensionality(set2), 1);
   }
 }


### PR DESCRIPTION
Computes the dimensionality of an arbitrary input set as the number of indices less the number of linearly independent effectively saturated constraints.

We don’t need to look at combinations of constraints or anything like that. All we need to do is test whether or not each constraint is effectively saturated based on the definitions in Theorem 1 of GR06.

This correctly handles issue #20, and is needed for issue #22.

---

There are two commits. The first adds several other isl helper functions. The second does the dimensionality computation.