### PR TITLE
Adding a NormalizeReductionDeep visitor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         org.junit.runner.JUnitCore alpha.model.tests.AlphaCheckProgramTest
         org.junit.runner.JUnitCore alpha.model.tests.AlphaNormalizeTest
         org.junit.runner.JUnitCore alpha.model.tests.AlphaShowTest
+        org.junit.runner.JUnitCore alpha.model.tests.transformation.reduction.NormalizeReductionDeepTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.DistributivityTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.FactorOutFromReductionTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.HigherOrderOperatorTest

--- a/bundles/alpha.model/src/alpha/model/transformation/reduction/NormalizeReductionDeep.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/reduction/NormalizeReductionDeep.xtend
@@ -1,0 +1,60 @@
+package alpha.model.transformation.reduction
+
+import alpha.model.AlphaExpressionVisitable
+import alpha.model.AlphaVisitable
+import alpha.model.Equation
+import alpha.model.ReduceExpression
+import alpha.model.util.AbstractAlphaCompleteVisitor
+import java.util.ArrayList
+
+/**
+ * Applies NormalizeReduction to all reduce expressions within the tree.
+ * Ensures that even nested reductions are moved to their own equations.
+ */
+class NormalizeReductionDeep extends AbstractAlphaCompleteVisitor {
+	/**
+	 * The list of reduce expressions to call NormalizeReduction on.
+	 * Constructing a list and then applying NormalizeReduction after walking the AST
+	 * prevents concurrent modification exceptions.
+	 */
+	val ArrayList<ReduceExpression> targetREs = newArrayList
+	
+	/**
+	 * Applies NormalizeReduction to all descendants of an equation, system body, system, etc.
+	 */
+	static def apply(AlphaVisitable av) {
+		val visitor = new NormalizeReductionDeep
+		visitor.accept(av)
+		visitor.normalizeTargets
+	}
+	
+	/**
+	 * Applies NormalizeReduction to all descendants of an expression.
+	 */
+	static def apply(AlphaExpressionVisitable ave) {
+		val visitor = new NormalizeReductionDeep
+		visitor.accept(ave)
+		visitor.normalizeTargets
+	}
+	
+	/**
+	 * Normalizes all of the target reduce expressions.
+	 * Calling this after walking the AST prevents concurrent modification exceptions.
+	 */
+	protected def normalizeTargets() {
+		targetREs.forEach[re | NormalizeReduction.apply(re)]
+	}
+	
+	/**
+	 * If the reduce expression isn't already the top-level expression
+	 * of an equation, add it to the list of reductions to normalize.
+	 */
+	override outReduceExpression(ReduceExpression re) {
+		// No need to create a new equation for the reduction if it's already
+		// the top-level expression of an equation.
+		if (re.eContainer instanceof Equation) {
+			return
+		}
+		targetREs += re
+	}
+}

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/NormalizeReductionDeep.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/NormalizeReductionDeep.java
@@ -1,0 +1,67 @@
+package alpha.model.transformation.reduction;
+
+import alpha.model.AlphaExpressionVisitable;
+import alpha.model.AlphaVisitable;
+import alpha.model.Equation;
+import alpha.model.ReduceExpression;
+import alpha.model.util.AbstractAlphaCompleteVisitor;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+
+/**
+ * Applies NormalizeReduction to all reduce expressions within the tree.
+ * Ensures that even nested reductions are moved to their own equations.
+ */
+@SuppressWarnings("all")
+public class NormalizeReductionDeep extends AbstractAlphaCompleteVisitor {
+  /**
+   * The list of reduce expressions to call NormalizeReduction on.
+   * Constructing a list and then applying NormalizeReduction after walking the AST
+   * prevents concurrent modification exceptions.
+   */
+  private final ArrayList<ReduceExpression> targetREs = CollectionLiterals.<ReduceExpression>newArrayList();
+
+  /**
+   * Applies NormalizeReduction to all descendants of an equation, system body, system, etc.
+   */
+  public static void apply(final AlphaVisitable av) {
+    final NormalizeReductionDeep visitor = new NormalizeReductionDeep();
+    visitor.accept(av);
+    visitor.normalizeTargets();
+  }
+
+  /**
+   * Applies NormalizeReduction to all descendants of an expression.
+   */
+  public static void apply(final AlphaExpressionVisitable ave) {
+    final NormalizeReductionDeep visitor = new NormalizeReductionDeep();
+    visitor.accept(ave);
+    visitor.normalizeTargets();
+  }
+
+  /**
+   * Normalizes all of the target reduce expressions.
+   * Calling this after walking the AST prevents concurrent modification exceptions.
+   */
+  protected void normalizeTargets() {
+    final Consumer<ReduceExpression> _function = (ReduceExpression re) -> {
+      NormalizeReduction.apply(re);
+    };
+    this.targetREs.forEach(_function);
+  }
+
+  /**
+   * If the reduce expression isn't already the top-level expression
+   * of an equation, add it to the list of reductions to normalize.
+   */
+  @Override
+  public void outReduceExpression(final ReduceExpression re) {
+    EObject _eContainer = re.eContainer();
+    if ((_eContainer instanceof Equation)) {
+      return;
+    }
+    this.targetREs.add(re);
+  }
+}

--- a/tests/alpha.model.tests/resources/src-valid/transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha
@@ -1,0 +1,17 @@
+affine topLevelReduction [N] -> {:N>10}
+	inputs	A: [N,N]
+	outputs X: [N]
+	let		X = reduce(+, (i,j->i), A[i,j]);
+.
+
+affine reductionInsideDependence [N] -> {:N>10}
+	inputs	A: [N,N]
+	outputs X: [N]
+	let		X = (a->N-a-1)@reduce(+, (i,j->i), A[i,j]);
+.
+
+affine nestedReduction [N] -> {:N>10}
+	inputs 	A,B: [N,N]
+	outputs X: [N]
+	let		X = reduce(max, (i,j->i), reduce(+, (i,j,k->i,j), A[i,k]*B[k,j]));
+.

--- a/tests/alpha.model.tests/resources/src-valid/transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha
@@ -10,8 +10,14 @@ affine reductionInsideDependence [N] -> {:N>10}
 	let		X = (a->N-a-1)@reduce(+, (i,j->i), A[i,j]);
 .
 
-affine nestedReduction [N] -> {:N>10}
+affine nestedReduction_01 [N] -> {:N>10}
 	inputs 	A,B: [N,N]
 	outputs X: [N]
 	let		X = reduce(max, (i,j->i), reduce(+, (i,j,k->i,j), A[i,k]*B[k,j]));
+.
+
+affine nestedReduction_02 [N] -> {:N>10}
+	inputs 	A,B: [N,N]
+	outputs X: [N]
+	let		X = reduce(max, (i,j->i), reduce(+, (i,j,k->i,j), reduce(*, (i,j,k,l->i,j,k), A[i,j]*B[k,l])));
 .

--- a/tests/alpha.model.tests/resources/src-valid/transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha
@@ -21,3 +21,9 @@ affine nestedReduction_02 [N] -> {:N>10}
 	outputs X: [N]
 	let		X = reduce(max, (i,j->i), reduce(+, (i,j,k->i,j), reduce(*, (i,j,k,l->i,j,k), A[i,j]*B[k,l])));
 .
+
+affine nestedReduction_03 [N] -> {:N>10}
+	inputs 	A,B,C: [N,N]
+	outputs X: [N]
+	let		X = reduce(max, (i,j->i), C[i,j] * reduce(+, (i,j,k->i,j), C[j,k] * reduce(*, (i,j,k,l->i,j,k), A[i,j]*B[k,l])));
+.

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/NormalizeReductionDeepTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/NormalizeReductionDeepTest.java
@@ -5,18 +5,17 @@ import alpha.commands.UtilityBase;
 import alpha.model.AlphaExpression;
 import alpha.model.AlphaModelLoader;
 import alpha.model.AlphaSystem;
+import alpha.model.BinaryExpression;
 import alpha.model.DependenceExpression;
 import alpha.model.ReduceExpression;
 import alpha.model.StandardEquation;
 import alpha.model.SystemBody;
 import alpha.model.VariableExpression;
 import alpha.model.transformation.reduction.NormalizeReductionDeep;
-import alpha.model.util.AShow;
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
-import org.eclipse.xtext.xbase.lib.InputOutput;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -215,7 +214,6 @@ public class NormalizeReductionDeepTest {
     AlphaExpression _body_1 = middleReduction.getBody();
     final ReduceExpression innerReduction = ((ReduceExpression) _body_1);
     NormalizeReductionDeep.apply(outerReduction);
-    InputOutput.<String>println(AShow.print(systemBody));
     Assert.assertEquals(originalEquation, outerReduction.eContainer());
     AlphaExpression _body_2 = outerReduction.getBody();
     Assert.assertTrue((_body_2 instanceof VariableExpression));
@@ -233,6 +231,55 @@ public class NormalizeReductionDeepTest {
     Assert.assertTrue((_body_4 instanceof VariableExpression));
     AlphaExpression _body_5 = middleReduction.getBody();
     final VariableExpression middleVariable = ((VariableExpression) _body_5);
+    final String innerEquationName = middleVariable.getVariable().getName();
+    final Function1<StandardEquation, Boolean> _function_1 = (StandardEquation eq) -> {
+      String _name = eq.getVariable().getName();
+      return Boolean.valueOf(Objects.equal(_name, innerEquationName));
+    };
+    final StandardEquation innerEquation = IterableExtensions.<StandardEquation>head(IterableExtensions.<StandardEquation>filter(Iterables.<StandardEquation>filter(systemBody.getEquations(), StandardEquation.class), _function_1));
+    Assert.assertNotNull(innerEquation);
+    Assert.assertEquals(innerEquation, innerReduction.eContainer());
+  }
+
+  /**
+   * Tests that applying NormalizeReductionDeep to the outermost reduction
+   * of a triply nested reduction will move all three reductions to their
+   * own equations. Both inner reductions are nested inside binary expressions.
+   */
+  @Test
+  public void nestedReduction_05() {
+    final SystemBody systemBody = Utility.GetSystemBody(NormalizeReductionDeepTest.getSystem("nestedReduction_03"));
+    final StandardEquation originalEquation = UtilityBase.GetEquation(systemBody, "X");
+    AlphaExpression _expr = originalEquation.getExpr();
+    final ReduceExpression outerReduction = ((ReduceExpression) _expr);
+    AlphaExpression _body = outerReduction.getBody();
+    final BinaryExpression outerBinary = ((BinaryExpression) _body);
+    AlphaExpression _right = outerBinary.getRight();
+    final ReduceExpression middleReduction = ((ReduceExpression) _right);
+    AlphaExpression _body_1 = middleReduction.getBody();
+    final BinaryExpression middleBinary = ((BinaryExpression) _body_1);
+    AlphaExpression _right_1 = middleBinary.getRight();
+    final ReduceExpression innerReduction = ((ReduceExpression) _right_1);
+    NormalizeReductionDeep.apply(outerReduction);
+    Assert.assertEquals(originalEquation, outerReduction.eContainer());
+    Assert.assertEquals(outerReduction.getBody(), outerBinary);
+    AlphaExpression _right_2 = outerBinary.getRight();
+    Assert.assertTrue((_right_2 instanceof VariableExpression));
+    AlphaExpression _right_3 = outerBinary.getRight();
+    final VariableExpression outerVariable = ((VariableExpression) _right_3);
+    final String middleEquationName = outerVariable.getVariable().getName();
+    final Function1<StandardEquation, Boolean> _function = (StandardEquation eq) -> {
+      String _name = eq.getVariable().getName();
+      return Boolean.valueOf(Objects.equal(_name, middleEquationName));
+    };
+    final StandardEquation middleEquation = IterableExtensions.<StandardEquation>head(IterableExtensions.<StandardEquation>filter(Iterables.<StandardEquation>filter(systemBody.getEquations(), StandardEquation.class), _function));
+    Assert.assertNotNull(middleEquation);
+    Assert.assertEquals(middleEquation, middleReduction.eContainer());
+    Assert.assertEquals(middleReduction, middleBinary.eContainer());
+    AlphaExpression _right_4 = middleBinary.getRight();
+    Assert.assertTrue((_right_4 instanceof VariableExpression));
+    AlphaExpression _right_5 = middleBinary.getRight();
+    final VariableExpression middleVariable = ((VariableExpression) _right_5);
     final String innerEquationName = middleVariable.getVariable().getName();
     final Function1<StandardEquation, Boolean> _function_1 = (StandardEquation eq) -> {
       String _name = eq.getVariable().getName();

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/NormalizeReductionDeepTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/NormalizeReductionDeepTest.java
@@ -1,0 +1,199 @@
+package alpha.model.tests.transformation.reduction;
+
+import alpha.commands.Utility;
+import alpha.commands.UtilityBase;
+import alpha.model.AlphaExpression;
+import alpha.model.AlphaModelLoader;
+import alpha.model.AlphaSystem;
+import alpha.model.DependenceExpression;
+import alpha.model.ReduceExpression;
+import alpha.model.StandardEquation;
+import alpha.model.SystemBody;
+import alpha.model.VariableExpression;
+import alpha.model.transformation.reduction.NormalizeReductionDeep;
+import com.google.common.base.Objects;
+import com.google.common.collect.Iterables;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class NormalizeReductionDeepTest {
+  /**
+   * The path to the Alpha file for these unit tests.
+   */
+  private static final String alphaFile = "resources/src-valid/transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha";
+
+  /**
+   * Gets the desired system for these unit tests.
+   */
+  public static AlphaSystem getSystem(final String system) {
+    try {
+      return UtilityBase.GetSystem(AlphaModelLoader.loadModel(NormalizeReductionDeepTest.alphaFile), system);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+
+  /**
+   * Gets the desired equation for these unit tests.
+   */
+  public static StandardEquation getEquation(final String system, final String equation) {
+    return UtilityBase.GetEquation(Utility.GetSystemBody(NormalizeReductionDeepTest.getSystem(system)), equation);
+  }
+
+  /**
+   * Tests that applying NormalizeReductionDeep to a system
+   * won't move a top-level reduction into a separate equation.
+   */
+  @Test
+  public void topLevelReduction_01() {
+    final AlphaSystem system = NormalizeReductionDeepTest.getSystem("topLevelReduction");
+    final StandardEquation equation = UtilityBase.GetEquation(Utility.GetSystemBody(system), "X");
+    AlphaExpression _expr = equation.getExpr();
+    final ReduceExpression reduction = ((ReduceExpression) _expr);
+    NormalizeReductionDeep.apply(system);
+    Assert.assertEquals(equation, reduction.eContainer());
+  }
+
+  /**
+   * Tests that applying NormalizeReductionDeep to an equation
+   * won't move a top-level reduction into a separate equation.
+   */
+  @Test
+  public void topLevelReduction_02() {
+    final StandardEquation equation = NormalizeReductionDeepTest.getEquation("topLevelReduction", "X");
+    AlphaExpression _expr = equation.getExpr();
+    final ReduceExpression reduction = ((ReduceExpression) _expr);
+    NormalizeReductionDeep.apply(equation);
+    Assert.assertEquals(equation, reduction.eContainer());
+  }
+
+  /**
+   * Tests that applying NormalizeReductionDeep to a top-level reduction
+   * won't move it into a separate equation.
+   */
+  @Test
+  public void topLevelReduction_03() {
+    final StandardEquation equation = NormalizeReductionDeepTest.getEquation("topLevelReduction", "X");
+    AlphaExpression _expr = equation.getExpr();
+    final ReduceExpression reduction = ((ReduceExpression) _expr);
+    NormalizeReductionDeep.apply(reduction);
+    Assert.assertEquals(equation, reduction.eContainer());
+  }
+
+  /**
+   * Tests that applying NormalizeReductionDeep will move a reduction
+   * that's inside a dependence expression to its own equation.
+   */
+  @Test
+  public void reductionInsideDependence_01() {
+    final SystemBody systemBody = Utility.GetSystemBody(NormalizeReductionDeepTest.getSystem("reductionInsideDependence"));
+    final StandardEquation originalEquation = UtilityBase.GetEquation(systemBody, "X");
+    AlphaExpression _expr = originalEquation.getExpr();
+    final DependenceExpression dependence = ((DependenceExpression) _expr);
+    AlphaExpression _expr_1 = dependence.getExpr();
+    final ReduceExpression reduction = ((ReduceExpression) _expr_1);
+    NormalizeReductionDeep.apply(reduction);
+    Assert.assertEquals(dependence, originalEquation.getExpr());
+    AlphaExpression _expr_2 = dependence.getExpr();
+    Assert.assertTrue((_expr_2 instanceof VariableExpression));
+    AlphaExpression _expr_3 = dependence.getExpr();
+    final VariableExpression variable = ((VariableExpression) _expr_3);
+    final String newEquationName = variable.getVariable().getName();
+    final Function1<StandardEquation, Boolean> _function = (StandardEquation eq) -> {
+      String _name = eq.getVariable().getName();
+      return Boolean.valueOf(Objects.equal(_name, newEquationName));
+    };
+    final StandardEquation newEquation = IterableExtensions.<StandardEquation>head(IterableExtensions.<StandardEquation>filter(Iterables.<StandardEquation>filter(systemBody.getEquations(), StandardEquation.class), _function));
+    Assert.assertNotNull(newEquation);
+    Assert.assertEquals(newEquation, reduction.eContainer());
+  }
+
+  /**
+   * Tests that applying NormalizeReductionDeep to a system
+   * will move a nested reduction to its own equation.
+   */
+  @Test
+  public void nestedReduction_01() {
+    final AlphaSystem system = NormalizeReductionDeepTest.getSystem("nestedReduction");
+    final SystemBody systemBody = Utility.GetSystemBody(system);
+    final StandardEquation originalEquation = UtilityBase.GetEquation(systemBody, "X");
+    AlphaExpression _expr = originalEquation.getExpr();
+    final ReduceExpression outerReduction = ((ReduceExpression) _expr);
+    AlphaExpression _body = outerReduction.getBody();
+    final ReduceExpression innerReduction = ((ReduceExpression) _body);
+    NormalizeReductionDeep.apply(system);
+    Assert.assertEquals(originalEquation, outerReduction.eContainer());
+    AlphaExpression _body_1 = outerReduction.getBody();
+    Assert.assertTrue((_body_1 instanceof VariableExpression));
+    AlphaExpression _body_2 = outerReduction.getBody();
+    final VariableExpression variable = ((VariableExpression) _body_2);
+    final String newEquationName = variable.getVariable().getName();
+    final Function1<StandardEquation, Boolean> _function = (StandardEquation eq) -> {
+      String _name = eq.getVariable().getName();
+      return Boolean.valueOf(Objects.equal(_name, newEquationName));
+    };
+    final StandardEquation newEquation = IterableExtensions.<StandardEquation>head(IterableExtensions.<StandardEquation>filter(Iterables.<StandardEquation>filter(systemBody.getEquations(), StandardEquation.class), _function));
+    Assert.assertNotNull(newEquation);
+    Assert.assertEquals(newEquation, innerReduction.eContainer());
+  }
+
+  /**
+   * Tests that applying NormalizeReductionDeep to an outer reduction
+   * will move a nested reduction to its own equation.
+   */
+  @Test
+  public void nestedReduction_02() {
+    final SystemBody systemBody = Utility.GetSystemBody(NormalizeReductionDeepTest.getSystem("nestedReduction"));
+    final StandardEquation originalEquation = UtilityBase.GetEquation(systemBody, "X");
+    AlphaExpression _expr = originalEquation.getExpr();
+    final ReduceExpression outerReduction = ((ReduceExpression) _expr);
+    AlphaExpression _body = outerReduction.getBody();
+    final ReduceExpression innerReduction = ((ReduceExpression) _body);
+    NormalizeReductionDeep.apply(outerReduction);
+    Assert.assertEquals(originalEquation, outerReduction.eContainer());
+    AlphaExpression _body_1 = outerReduction.getBody();
+    Assert.assertTrue((_body_1 instanceof VariableExpression));
+    AlphaExpression _body_2 = outerReduction.getBody();
+    final VariableExpression variable = ((VariableExpression) _body_2);
+    final String newEquationName = variable.getVariable().getName();
+    final Function1<StandardEquation, Boolean> _function = (StandardEquation eq) -> {
+      String _name = eq.getVariable().getName();
+      return Boolean.valueOf(Objects.equal(_name, newEquationName));
+    };
+    final StandardEquation newEquation = IterableExtensions.<StandardEquation>head(IterableExtensions.<StandardEquation>filter(Iterables.<StandardEquation>filter(systemBody.getEquations(), StandardEquation.class), _function));
+    Assert.assertNotNull(newEquation);
+    Assert.assertEquals(newEquation, innerReduction.eContainer());
+  }
+
+  /**
+   * Tests that applying NormalizeReductionDeep to an inner reduction
+   * will move it to its own equation.
+   */
+  @Test
+  public void nestedReduction_03() {
+    final SystemBody systemBody = Utility.GetSystemBody(NormalizeReductionDeepTest.getSystem("nestedReduction"));
+    final StandardEquation originalEquation = UtilityBase.GetEquation(systemBody, "X");
+    AlphaExpression _expr = originalEquation.getExpr();
+    final ReduceExpression outerReduction = ((ReduceExpression) _expr);
+    AlphaExpression _body = outerReduction.getBody();
+    final ReduceExpression innerReduction = ((ReduceExpression) _body);
+    NormalizeReductionDeep.apply(innerReduction);
+    Assert.assertEquals(originalEquation, outerReduction.eContainer());
+    AlphaExpression _body_1 = outerReduction.getBody();
+    Assert.assertTrue((_body_1 instanceof VariableExpression));
+    AlphaExpression _body_2 = outerReduction.getBody();
+    final VariableExpression variable = ((VariableExpression) _body_2);
+    final String newEquationName = variable.getVariable().getName();
+    final Function1<StandardEquation, Boolean> _function = (StandardEquation eq) -> {
+      String _name = eq.getVariable().getName();
+      return Boolean.valueOf(Objects.equal(_name, newEquationName));
+    };
+    final StandardEquation newEquation = IterableExtensions.<StandardEquation>head(IterableExtensions.<StandardEquation>filter(Iterables.<StandardEquation>filter(systemBody.getEquations(), StandardEquation.class), _function));
+    Assert.assertNotNull(newEquation);
+    Assert.assertEquals(newEquation, innerReduction.eContainer());
+  }
+}


### PR DESCRIPTION
It calls NormalizeReduction on all reductions within an AST as long as the reduction isn't already the top-level expression within an equation.