### PR TITLE
Fixing the dependence raising rule for restrictions

### DIFF
--- a/bundles/alpha.model/src/alpha/model/transformation/Normalize.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/Normalize.xtend
@@ -17,6 +17,7 @@ import alpha.model.ModelPackage
 import alpha.model.MultiArgExpression
 import alpha.model.RestrictExpression
 import alpha.model.UnaryExpression
+import alpha.model.factory.AlphaUserFactory
 import alpha.model.util.AbstractAlphaCompleteVisitor
 import alpha.model.util.AlphaExpressionUtil
 import alpha.model.util.AlphaUtil
@@ -35,8 +36,8 @@ import static alpha.model.factory.AlphaUserFactory.createJNIDomain
 import static alpha.model.factory.AlphaUserFactory.createJNIFunction
 import static alpha.model.factory.AlphaUserFactory.createRestrictExpression
 import static alpha.model.factory.AlphaUserFactory.createUnaryExpression
-import alpha.model.factory.AlphaUserFactory
-import alpha.model.ConstantExpression
+
+import static extension alpha.model.util.ISLUtil.isNoneToNone
 
 /**
  * Normalization of Alpha programs.
@@ -202,7 +203,7 @@ class Normalize extends AbstractAlphaCompleteVisitor {
 		// if the function has no inputs or outputs, which may occur in dependence raising.
 		// This is caused because the "isIdentity" function tries to build an identity function
 		// from the dependence function's space, but can't do so if there are no inputs or outputs.
-		if ((de.function.nbInputs > 0) &&  de.function.isIdentity) {
+		if (de.function.isNoneToNone || de.function.isIdentity) {
 			debug("identity", "f @ E = E if f = I");
 			EcoreUtil.replace(de, de.expr);
 		}

--- a/bundles/alpha.model/src/alpha/model/transformation/Normalize.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/Normalize.xtend
@@ -36,6 +36,7 @@ import static alpha.model.factory.AlphaUserFactory.createJNIFunction
 import static alpha.model.factory.AlphaUserFactory.createRestrictExpression
 import static alpha.model.factory.AlphaUserFactory.createUnaryExpression
 import alpha.model.factory.AlphaUserFactory
+import alpha.model.ConstantExpression
 
 /**
  * Normalization of Alpha programs.
@@ -197,7 +198,11 @@ class Normalize extends AbstractAlphaCompleteVisitor {
 		dependenceExpressionRules(de, de.expr);
 
 		// f @ E = E if f = I
-		if (de.function.isIdentity) {
+		// Note: checking if a function is the identity function fails
+		// if the function has no inputs or outputs, which may occur in dependence raising.
+		// This is caused because the "isIdentity" function tries to build an identity function
+		// from the dependence function's space, but can't do so if there are no inputs or outputs.
+		if ((de.function.nbInputs > 0) &&  de.function.isIdentity) {
 			debug("identity", "f @ E = E if f = I");
 			EcoreUtil.replace(de, de.expr);
 		}

--- a/bundles/alpha.model/src/alpha/model/util/ISLUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/ISLUtil.xtend
@@ -7,13 +7,12 @@ import fr.irisa.cairn.jnimap.isl.ISLConstraint
 import fr.irisa.cairn.jnimap.isl.ISLContext
 import fr.irisa.cairn.jnimap.isl.ISLDimType
 import fr.irisa.cairn.jnimap.isl.ISLMatrix
+import fr.irisa.cairn.jnimap.isl.ISLMultiAff
 import fr.irisa.cairn.jnimap.isl.ISLSet
 
 import static extension alpha.model.matrix.MatrixOperations.scalarMultiplication
 import static extension alpha.model.matrix.MatrixOperations.transpose
 import static extension alpha.model.util.DomainOperations.*
-
-import static extension java.lang.Math.abs
 
 class ISLUtil {
 	
@@ -45,6 +44,11 @@ class ISLUtil {
 	/** Returns the integer point closest to the origin in set without parameter context */
 	def static long[] integerPointClosestToOrigin(ISLBasicSet set) {
 		set.copy.samplePoint.coordinates.subList(set.nbParams, set.nbParams + set.nbIndices)
+	}
+	
+	/** Checks if this is a function from an empty domain to an empty range. */
+	def static isNoneToNone(ISLMultiAff aff) {
+		return (aff.nbInputs == 0) && (aff.nbOutputs == 0)
 	}
 	
 	def static isTrivial(ISLBasicSet set) {

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/Normalize.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/Normalize.java
@@ -23,6 +23,7 @@ import alpha.model.issue.AlphaIssue;
 import alpha.model.util.AbstractAlphaCompleteVisitor;
 import alpha.model.util.AlphaExpressionUtil;
 import alpha.model.util.AlphaUtil;
+import alpha.model.util.ISLUtil;
 import alpha.model.util.Show;
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
@@ -221,7 +222,7 @@ public class Normalize extends AbstractAlphaCompleteVisitor {
       return;
     }
     this.dependenceExpressionRules(de, de.getExpr());
-    if (((de.getFunction().getNbInputs() > 0) && de.getFunction().isIdentity())) {
+    if ((ISLUtil.isNoneToNone(de.getFunction()) || de.getFunction().isIdentity())) {
       this.debug("identity", "f @ E = E if f = I");
       EcoreUtil.replace(de, de.getExpr());
     }

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/Normalize.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/Normalize.java
@@ -221,8 +221,7 @@ public class Normalize extends AbstractAlphaCompleteVisitor {
       return;
     }
     this.dependenceExpressionRules(de, de.getExpr());
-    boolean _isIdentity = de.getFunction().isIdentity();
-    if (_isIdentity) {
+    if (((de.getFunction().getNbInputs() > 0) && de.getFunction().isIdentity())) {
       this.debug("identity", "f @ E = E if f = I");
       EcoreUtil.replace(de, de.getExpr());
     }

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/ISLUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/ISLUtil.java
@@ -8,6 +8,7 @@ import fr.irisa.cairn.jnimap.isl.ISLConstraint;
 import fr.irisa.cairn.jnimap.isl.ISLContext;
 import fr.irisa.cairn.jnimap.isl.ISLDimType;
 import fr.irisa.cairn.jnimap.isl.ISLMatrix;
+import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
 import fr.irisa.cairn.jnimap.isl.ISLSet;
 import java.util.List;
 import org.eclipse.xtext.xbase.lib.Conversions;
@@ -64,6 +65,13 @@ public class ISLUtil {
     int _nbIndices = set.getNbIndices();
     int _plus = (_nbParams_1 + _nbIndices);
     return ((long[])Conversions.unwrapArray(_coordinates.subList(_nbParams, _plus), long.class));
+  }
+
+  /**
+   * Checks if this is a function from an empty domain to an empty range.
+   */
+  public static boolean isNoneToNone(final ISLMultiAff aff) {
+    return ((aff.getNbInputs() == 0) && (aff.getNbOutputs() == 0));
   }
 
   public static boolean isTrivial(final ISLBasicSet set) {

--- a/tests/alpha.model.tests/resources/src-valid/transformation-tests/raise-dependence/raiseDependence.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-tests/raise-dependence/raiseDependence.alpha
@@ -49,7 +49,7 @@ package alpha.model.tests.transformations.raiseDependence {
 	affine restrictExpression_01 [N] -> {: N > 0}
 		inputs  A: {[i]: 0 <= i < 3N}
 		outputs X: {[i]: N <= i < 2N}
-		let     X[i] = case { {[i]: i>=N}: A[i-N]; };
+		let     X[i] = {[i]: i>=N}: A[i-N];
 	.
 	
 	affine autoRestrictExpression_01 [N] -> {: N > 0}
@@ -137,5 +137,15 @@ package alpha.model.tests.transformations.raiseDependence {
 				B: {[i]: N <= i < 2N}
 		outputs X: {[i]: 0 <= i < 2N}
 		let     X[i] = case { A[i]; B[i]; };
+	.
+	
+	
+	////////////////////////////////////////////////////////////
+	// Miscellaneous Tests
+	////////////////////////////////////////////////////////////
+	affine prefixScan [N] -> {: N > 0}
+		inputs  A: [N]
+		outputs X: [N]
+		let     X[i] = reduce(+, (i,j->i), {:j<=i}: A[j]);
 	.
 }

--- a/tests/alpha.model.tests/resources/src-valid/transformation-tests/raise-dependence/raiseDependence.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-tests/raise-dependence/raiseDependence.alpha
@@ -1,4 +1,6 @@
 package alpha.model.tests.transformations.raiseDependence {
+	external test(2)
+	
 	////////////////////////////////////////////////////////////
 	// Constant, Variable, and Index Expression Rules
 	////////////////////////////////////////////////////////////
@@ -130,6 +132,12 @@ package alpha.model.tests.transformations.raiseDependence {
 				C: [4N]
 		outputs X: [N]
 		let     X[i] = max(A[2i], B[N-i], C[i+1]);
+	.
+	
+	// External functions like this should be treated as multi-arg expressions.
+	affine externalFunctionTest_01 [N] -> {: N > 0}
+		outputs X: [N,N]
+		let     X[i,j] = test(val[i+j], val[i+j]);
 	.
 	
 	affine caseTest_01 [N] -> {: N > 0}

--- a/tests/alpha.model.tests/src/alpha/model/tests/transformations/RaiseDependenceTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/transformations/RaiseDependenceTest.xtend
@@ -648,12 +648,7 @@ class RaiseDependenceTest {
 	// Normalizing Undoes Dependence Raising
 	////////////////////////////////////////////////////////////
 
-	// Note: this test does not work, as the normalized original program outputs "X = 7",
-	// but the normalized program after dependence raising outputs "X = 7[]",
-	// as there is a dependence function with no outputs (i.e., map to a scalar)
-	// around the constant, which normalizing does not remove.
-	// However, looking at the output and AST shows that this works as expected as of 16-Apr-2024.
-//	@Test def normalizeUndoesRaising_Test01() { normalizeTest("wrapConstantExpression_01", "X") }
+	@Test def normalizeUndoesRaising_Test01() { normalizeTest("wrapConstantExpression_01", "X") }
 	
 	@Test def normalizeUndoesRaising_Test02() { normalizeTest("wrapVariableExpression_01", "X") }
 	

--- a/tests/alpha.model.tests/src/alpha/model/tests/transformations/RaiseDependenceTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/transformations/RaiseDependenceTest.xtend
@@ -22,6 +22,9 @@ import static org.junit.Assert.*
 import static extension alpha.commands.Utility.*
 import static extension alpha.commands.UtilityBase.*
 import static extension alpha.model.util.CommonExtensions.toHashMap
+import alpha.model.transformation.Normalize
+import alpha.model.util.AShow
+import alpha.model.transformation.LiftAutoRestrict
 
 class RaiseDependenceTest {
 	/** The path to the Alpha file for these unit tests. */
@@ -162,73 +165,106 @@ class RaiseDependenceTest {
 	
 	@Test
 	def restrictExpression_01() {
-		// From:  case { D:(f@E); }
-		// To:    f1 @ case { f2 @ (f(D) : E); }
-		// Where: f = f1@f2
+		// From:  D:(f@E)
+		// To:    f1@(D1: f2@E)
+		// Where: D=Preimage(D1,f1) and f=f1 @ f2
 		
 		val equation = getEquation("restrictExpression_01", "X")
 		
-		val originalCase = equation.expr as CaseExpression
-		val originalRestrict = originalCase.exprs.get(0) as RestrictExpression
+		
+		// Capture the original AST nodes we need and extract D and f from them
+		val originalRestrict = equation.expr as RestrictExpression
 		val originalDependence = originalRestrict.expr as DependenceExpression
+
+		val d = originalRestrict.restrictDomain.copy
+		val f = originalDependence.function.copy
+
+		RaiseDependence.apply(equation.expr)
 		
-		val expectedDependenceFunction = originalDependence.function.copy
-		val expectedRestrictDomain = originalRestrict.restrictDomain.copy.apply(expectedDependenceFunction.copy.toMap)
+		// The top-level node of the equation should now be the f1 dependence expression.
+		assertTrue(equation.expr instanceof DependenceExpression)
+		val outerDependence = equation.expr as DependenceExpression
+		val f1 = outerDependence.function
 		
-		assertSingleRestrictionCorrect(equation, expectedRestrictDomain, expectedDependenceFunction)
+		// Inside there is the D1 restriction expression.
+		assertTrue(outerDependence.expr instanceof RestrictExpression)
+		val updatedRestrict = outerDependence.expr as RestrictExpression
+		val d1 = updatedRestrict.restrictDomain
+		
+		// Finally, there is an inner dependence function, f2, inside the restriction.
+		assertTrue(updatedRestrict.expr instanceof DependenceExpression)
+		val innerDependence = updatedRestrict.expr as DependenceExpression
+		val f2 = innerDependence.function
+		
+		// We require that f = f1 @ f2.
+		assertTrue(f.isPlainEqual(f2.pullback(f1.copy)))
+		
+		// We require that D is the preimage of D1 by f1.
+		assertTrue(d.isPlainEqual(d1.preimage(f1)))
 	}
 	
 	@Test
 	def autoRestrictExpression_01() {
 		// From:  case { auto: f @ E }
-		// To:    f1 @ case { f2 @ (D:E) }
-		// Where: f = f1@f2 and D is a restriction to the context domain.
+		// To:    f1 @ case { f2 @ (D1: f3 @ E) }
+		// Where: f = f1@f2@f3 and the context domain of f is the preimage of D1 by f1@f2.
 		
 		val equation = getEquation("autoRestrictExpression_01", "X")
 		
+		// Capture the original AST nodes we need.
 		val originalCase = equation.expr as CaseExpression
 		val originalRestrict = originalCase.exprs.get(0) as AutoRestrictExpression
 		val originalDependence = originalRestrict.expr as DependenceExpression
 		
-		val expectedDependenceFunction = originalDependence.function.copy
-		val expectedRestrictDomain = originalDependence.expr.contextDomain.copy
+		// We will use the context domain of the original restriction (f)
+		// as our original domain (D).
+		val f = originalDependence.function.copy
+		val d = originalDependence.contextDomain.copy 
 		
-		assertSingleRestrictionCorrect(equation, expectedRestrictDomain, expectedDependenceFunction)
-	}
-	
-	static def assertSingleRestrictionCorrect(StandardEquation equation, ISLSet expectedRestrictDomain, ISLMultiAff expectedDependenceFunction) {
 		RaiseDependence.apply(equation.expr)
 		
-		// The equation should now be a dependence expression (f1) at the top level.
-		// Inside that should be a case expression with a single dependence expression (f2).
-		// Inside there is a restrict expression with the expected domain.
+		// Since dependence raising was also applied to the case statement
+		// (it's required for the auto-restrict to be correctly replaced with a standard restrict),
+		// the top-level will be the f1 dependence.
 		assertTrue(equation.expr instanceof DependenceExpression)
 		val outerDependence = equation.expr as DependenceExpression
 		val f1 = outerDependence.function
 		
+		// Inside f1 is our case statement.
 		assertTrue(outerDependence.expr instanceof CaseExpression)
 		val updatedCase = outerDependence.expr as CaseExpression
 		
+		// The case statement should only have one child, which is the dependence f2.
 		assertEquals(1, updatedCase.exprs.size)
 		assertTrue(updatedCase.exprs.get(0) instanceof DependenceExpression)
-		val innerDependence = updatedCase.exprs.get(0) as DependenceExpression
-		val f2 = innerDependence.function
+		val middleDependence = updatedCase.exprs.get(0) as DependenceExpression
+		val f2 = middleDependence.function
 		
-		val updatedRestrict = innerDependence.expr as RestrictExpression
+		// Our updated restriction D1 (which is no longer an auto-restrict) is inside f2.
+		assertTrue(middleDependence.expr instanceof RestrictExpression)
+		val updatedRestriction = middleDependence.expr as RestrictExpression
+		val d1 = updatedRestriction.restrictDomain
 		
-		// Check that the restrict domain is correct and that f = f1@f2
-		assertTrue(updatedRestrict.restrictDomain.isEqual(expectedRestrictDomain))
-		assertTrue(expectedDependenceFunction.isPlainEqual(f2.pullback(f1)))
+		// Finally, the f3 dependence is inside that restriction.
+		assertTrue(updatedRestriction.expr instanceof DependenceExpression)
+		val innerDependence = updatedRestriction.expr as DependenceExpression
+		val f3 = innerDependence.function
 		
+		// We require that f = f1 @ f2 @ f3.
+		assertTrue(f.isPlainEqual(f3.pullback(f2.copy.pullback(f1.copy))))
+		
+		// We require that D is the preimage of D1 by f1 @ f2.
+		assertTrue(d.isPlainEqual(d1.preimage(f2.pullback(f1))))
 	}
 	
 	@Test
 	def autoRestrictExpression_02() {
 		// From:  case { D1: f1@E1; auto: f2 @ E2 }
-		// To:    f' @ case { f1' @ (f1(D1): E1); f2' @ (D2: E2) }
-		// Where: fn = f'@fn' and D2 is a restriction to the context domain.
+		// To:    f' @ case { f1' @ (D1': f1" @ E1); f2' @ (D2': f2" @ E2) }
+		// Where: fn = f'@fn'@fn", D1 = Preimage(D1', f'@f1')
+		//        and the context domain of f2 equals Preimage(D2', f'@f2')
 		
-		// Get the original equation and extract d1, d2, f1, and f2.
+		// Get the original equation and extract the required domains and dependences.
 		val equation = getEquation("autoRestrictExpression_02", "X")
 		
 		val originalCase = equation.expr as CaseExpression
@@ -244,39 +280,60 @@ class RaiseDependenceTest {
 		val f1 = originalDependence1.function.copy
 		val f2 = originalDependence2.function.copy
 		
-		// Apply dependence raising and check that the AST is correct.
 		RaiseDependence.apply(equation.expr)
-		
+
+		// Since applied dependence raising to the entire expression (to fix the auto-restrict),
+		// the top-level expression is the dependence f'.		
 		assertTrue(equation.expr instanceof DependenceExpression)
 		val outerDependence = equation.expr as DependenceExpression
+		val fPrime = outerDependence.function
 		
+		// Inside there is our case expression, which must have two children.
 		assertTrue(outerDependence.expr instanceof CaseExpression)
 		val updatedCase = outerDependence.expr as CaseExpression
-		
 		assertEquals(2, updatedCase.exprs.size)
+		
+		// The first child is the dependence function f1'.
+		// This contains our restriction D1' and the remaining term f1".
 		assertTrue(updatedCase.exprs.get(0) instanceof DependenceExpression)
-		assertTrue(updatedCase.exprs.get(1) instanceof DependenceExpression)
 		val updatedDep1 = updatedCase.exprs.get(0) as DependenceExpression
-		val updatedDep2 = updatedCase.exprs.get(1) as DependenceExpression
+		val f1Prime = updatedDep1.function
 		
 		assertTrue(updatedDep1.expr instanceof RestrictExpression)
 		val updatedRestrict1 = updatedDep1.expr as RestrictExpression
-		val updatedRestrict2 = updatedDep2.expr as RestrictExpression
-		
-		// Extract out the actual domains and dependence functions.
 		val d1Prime = updatedRestrict1.restrictDomain
+		
+		assertTrue(updatedRestrict1.expr instanceof DependenceExpression)
+		val innermostDep1 = updatedRestrict1.expr as DependenceExpression
+		val f1Prime2 = innermostDep1.function
+
+		// The second child is the dependence function f2'.
+		// This contains our restriction D2' and the remaining term f2".
+		assertTrue(updatedCase.exprs.get(1) instanceof DependenceExpression)
+		val updatedDep2 = updatedCase.exprs.get(1) as DependenceExpression
+		val f2Prime = updatedDep2.function
+		
+		assertTrue(updatedDep2.expr instanceof RestrictExpression)
+		val updatedRestrict2 = updatedDep2.expr as RestrictExpression
 		val d2Prime = updatedRestrict2.restrictDomain
 		
-		val fPrime = outerDependence.function.copy
-		val f1Prime = updatedDep1.function.copy
-		val f2Prime = updatedDep2.function.copy
+		assertTrue(updatedRestrict2.expr instanceof DependenceExpression)
+		val innermostDep2 = updatedRestrict2.expr as DependenceExpression
+		val f2Prime2 = innermostDep2.function
 		
-		// Check that everything is still correct.
-		assertTrue(d1Prime.isEqual(d1.apply(f1.copy.toMap)))
-		assertTrue(d2Prime.isEqual(d2.apply(f2.copy.toMap)))
+		// We require f1 = f' @ f1' @ f1"
+		val fPrimeAtF1Prime = f1Prime.copy.pullback(fPrime.copy)
+		assertTrue(f1.isPlainEqual(f1Prime2.pullback(fPrimeAtF1Prime.copy)))
 		
-		assertTrue(f1.isPlainEqual(f1Prime.pullback(fPrime.copy)))
-		assertTrue(f2.isPlainEqual(f2Prime.pullback(fPrime)))
+		// We require f2 = f' @ f2' @ f2"
+		val fPrimeAtF2Prime = f2Prime.copy.pullback(fPrime.copy)
+		assertTrue(f2.isPlainEqual(f2Prime2.pullback(fPrimeAtF2Prime.copy)))
+		
+		// We require D1 = Preimage(D1', f' @ f1')
+		assertTrue(d1.isEqual(d1Prime.preimage(fPrimeAtF1Prime)))
+				
+		// We require D2 = Preimage(D2', f' @ f2')
+		assertTrue(d2.isEqual(d2Prime.preimage(fPrimeAtF2Prime)))
 	}
 	
 	
@@ -537,5 +594,70 @@ class RaiseDependenceTest {
 			val actual = remainingTerms.get(innerExpr).pullback(commonFactor.copy())
 			assertTrue(expected.isPlainEqual(actual))
 		}
+	}
+	
+	
+	////////////////////////////////////////////////////////////
+	// Normalizing Undoes Dependence Raising
+	////////////////////////////////////////////////////////////
+
+	// Note: this test does not work, as the normalized original program outputs "X = 7",
+	// but the normalized program after dependence raising outputs "X = 7[]",
+	// as there is a dependence function with no outputs (i.e., map to a scalar)
+	// around the constant, which normalizing does not remove.
+	// However, looking at the output and AST shows that this works as expected as of 16-Apr-2024.
+//	@Test def normalizeUndoesRaising_Test01() { normalizeTest("wrapConstantExpression_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test02() { normalizeTest("wrapVariableExpression_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test03() { normalizeTest("wrapVariableExpression_02", "X") }
+	
+	@Test def normalizeUndoesRaising_Test04() { normalizeTest("wrapIndexExpression_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test05() { normalizeTest("wrapIndexExpression_02", "X") }
+	
+	@Test def normalizeUndoesRaising_Test06() { normalizeTest("nestedDependenceFunction_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test07() { normalizeTest("restrictExpression_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test08() { normalizeTest("autoRestrictExpression_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test09() { normalizeTest("autoRestrictExpression_02", "X") }
+	
+	@Test def normalizeUndoesRaising_Test10() { normalizeTest("unaryExpression_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test11() { normalizeTest("simpleBinaryExpression_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test12() { normalizeTest("binaryExpressionBecomesNested_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test13() { normalizeTest("binaryExpressionBecomesNested_02", "X") }
+	
+	@Test def normalizeUndoesRaising_Test14() { normalizeTest("binaryExpressionBecomesNested_03", "X") }
+	
+	@Test def normalizeUndoesRaising_Test15() { normalizeTest("binaryExpressionBecomesNested_04", "X") }
+	
+	@Test def normalizeUndoesRaising_Test16() { normalizeTest("multiArgTest_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test17() { normalizeTest("caseTest_01", "X") }
+	
+	@Test def normalizeUndoesRaising_Test18() { normalizeTest("prefixScan", "X") }
+
+	/**
+	 * Used by several tests to ensure that the system can be normalized,
+	 * dependence raising can be applied, and then normalized again
+	 * to recreate the original normalization.
+	 */
+	static def normalizeTest(String systemName, String equationName) {
+		val equation = getEquation(systemName, equationName)
+		
+		LiftAutoRestrict.apply(equation)
+		Normalize.apply(equation)
+		val expected = AShow.print(equation)
+		
+		RaiseDependence.apply(equation)
+		Normalize.apply(equation)
+		val actual = AShow.print(equation)
+		
+		assertEquals(expected, actual)
 	}
 }

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/RaiseDependenceTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/RaiseDependenceTest.java
@@ -15,7 +15,10 @@ import alpha.model.RestrictExpression;
 import alpha.model.StandardEquation;
 import alpha.model.UnaryExpression;
 import alpha.model.VariableExpression;
+import alpha.model.transformation.LiftAutoRestrict;
+import alpha.model.transformation.Normalize;
 import alpha.model.transformation.RaiseDependence;
+import alpha.model.util.AShow;
 import alpha.model.util.CommonExtensions;
 import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
 import fr.irisa.cairn.jnimap.isl.ISLSet;
@@ -146,14 +149,29 @@ public class RaiseDependenceTest {
   public void restrictExpression_01() {
     final StandardEquation equation = RaiseDependenceTest.getEquation("restrictExpression_01", "X");
     AlphaExpression _expr = equation.getExpr();
-    final CaseExpression originalCase = ((CaseExpression) _expr);
-    AlphaExpression _get = originalCase.getExprs().get(0);
-    final RestrictExpression originalRestrict = ((RestrictExpression) _get);
+    final RestrictExpression originalRestrict = ((RestrictExpression) _expr);
     AlphaExpression _expr_1 = originalRestrict.getExpr();
     final DependenceExpression originalDependence = ((DependenceExpression) _expr_1);
-    final ISLMultiAff expectedDependenceFunction = originalDependence.getFunction().copy();
-    final ISLSet expectedRestrictDomain = originalRestrict.getRestrictDomain().copy().apply(expectedDependenceFunction.copy().toMap());
-    RaiseDependenceTest.assertSingleRestrictionCorrect(equation, expectedRestrictDomain, expectedDependenceFunction);
+    final ISLSet d = originalRestrict.getRestrictDomain().copy();
+    final ISLMultiAff f = originalDependence.getFunction().copy();
+    RaiseDependence.apply(equation.getExpr());
+    AlphaExpression _expr_2 = equation.getExpr();
+    Assert.assertTrue((_expr_2 instanceof DependenceExpression));
+    AlphaExpression _expr_3 = equation.getExpr();
+    final DependenceExpression outerDependence = ((DependenceExpression) _expr_3);
+    final ISLMultiAff f1 = outerDependence.getFunction();
+    AlphaExpression _expr_4 = outerDependence.getExpr();
+    Assert.assertTrue((_expr_4 instanceof RestrictExpression));
+    AlphaExpression _expr_5 = outerDependence.getExpr();
+    final RestrictExpression updatedRestrict = ((RestrictExpression) _expr_5);
+    final ISLSet d1 = updatedRestrict.getRestrictDomain();
+    AlphaExpression _expr_6 = updatedRestrict.getExpr();
+    Assert.assertTrue((_expr_6 instanceof DependenceExpression));
+    AlphaExpression _expr_7 = updatedRestrict.getExpr();
+    final DependenceExpression innerDependence = ((DependenceExpression) _expr_7);
+    final ISLMultiAff f2 = innerDependence.getFunction();
+    Assert.assertTrue(f.isPlainEqual(f2.pullback(f1.copy())));
+    Assert.assertTrue(d.isPlainEqual(d1.preimage(f1)));
   }
 
   @Test
@@ -165,32 +183,36 @@ public class RaiseDependenceTest {
     final AutoRestrictExpression originalRestrict = ((AutoRestrictExpression) _get);
     AlphaExpression _expr_1 = originalRestrict.getExpr();
     final DependenceExpression originalDependence = ((DependenceExpression) _expr_1);
-    final ISLMultiAff expectedDependenceFunction = originalDependence.getFunction().copy();
-    final ISLSet expectedRestrictDomain = originalDependence.getExpr().getContextDomain().copy();
-    RaiseDependenceTest.assertSingleRestrictionCorrect(equation, expectedRestrictDomain, expectedDependenceFunction);
-  }
-
-  public static void assertSingleRestrictionCorrect(final StandardEquation equation, final ISLSet expectedRestrictDomain, final ISLMultiAff expectedDependenceFunction) {
+    final ISLMultiAff f = originalDependence.getFunction().copy();
+    final ISLSet d = originalDependence.getContextDomain().copy();
     RaiseDependence.apply(equation.getExpr());
-    AlphaExpression _expr = equation.getExpr();
-    Assert.assertTrue((_expr instanceof DependenceExpression));
-    AlphaExpression _expr_1 = equation.getExpr();
-    final DependenceExpression outerDependence = ((DependenceExpression) _expr_1);
+    AlphaExpression _expr_2 = equation.getExpr();
+    Assert.assertTrue((_expr_2 instanceof DependenceExpression));
+    AlphaExpression _expr_3 = equation.getExpr();
+    final DependenceExpression outerDependence = ((DependenceExpression) _expr_3);
     final ISLMultiAff f1 = outerDependence.getFunction();
-    AlphaExpression _expr_2 = outerDependence.getExpr();
-    Assert.assertTrue((_expr_2 instanceof CaseExpression));
-    AlphaExpression _expr_3 = outerDependence.getExpr();
-    final CaseExpression updatedCase = ((CaseExpression) _expr_3);
+    AlphaExpression _expr_4 = outerDependence.getExpr();
+    Assert.assertTrue((_expr_4 instanceof CaseExpression));
+    AlphaExpression _expr_5 = outerDependence.getExpr();
+    final CaseExpression updatedCase = ((CaseExpression) _expr_5);
     Assert.assertEquals(1, updatedCase.getExprs().size());
-    AlphaExpression _get = updatedCase.getExprs().get(0);
-    Assert.assertTrue((_get instanceof DependenceExpression));
     AlphaExpression _get_1 = updatedCase.getExprs().get(0);
-    final DependenceExpression innerDependence = ((DependenceExpression) _get_1);
-    final ISLMultiAff f2 = innerDependence.getFunction();
-    AlphaExpression _expr_4 = innerDependence.getExpr();
-    final RestrictExpression updatedRestrict = ((RestrictExpression) _expr_4);
-    Assert.assertTrue(updatedRestrict.getRestrictDomain().isEqual(expectedRestrictDomain));
-    Assert.assertTrue(expectedDependenceFunction.isPlainEqual(f2.pullback(f1)));
+    Assert.assertTrue((_get_1 instanceof DependenceExpression));
+    AlphaExpression _get_2 = updatedCase.getExprs().get(0);
+    final DependenceExpression middleDependence = ((DependenceExpression) _get_2);
+    final ISLMultiAff f2 = middleDependence.getFunction();
+    AlphaExpression _expr_6 = middleDependence.getExpr();
+    Assert.assertTrue((_expr_6 instanceof RestrictExpression));
+    AlphaExpression _expr_7 = middleDependence.getExpr();
+    final RestrictExpression updatedRestriction = ((RestrictExpression) _expr_7);
+    final ISLSet d1 = updatedRestriction.getRestrictDomain();
+    AlphaExpression _expr_8 = updatedRestriction.getExpr();
+    Assert.assertTrue((_expr_8 instanceof DependenceExpression));
+    AlphaExpression _expr_9 = updatedRestriction.getExpr();
+    final DependenceExpression innerDependence = ((DependenceExpression) _expr_9);
+    final ISLMultiAff f3 = innerDependence.getFunction();
+    Assert.assertTrue(f.isPlainEqual(f3.pullback(f2.copy().pullback(f1.copy()))));
+    Assert.assertTrue(d.isPlainEqual(d1.preimage(f2.pullback(f1))));
   }
 
   @Test
@@ -215,6 +237,7 @@ public class RaiseDependenceTest {
     Assert.assertTrue((_expr_3 instanceof DependenceExpression));
     AlphaExpression _expr_4 = equation.getExpr();
     final DependenceExpression outerDependence = ((DependenceExpression) _expr_4);
+    final ISLMultiAff fPrime = outerDependence.getFunction();
     AlphaExpression _expr_5 = outerDependence.getExpr();
     Assert.assertTrue((_expr_5 instanceof CaseExpression));
     AlphaExpression _expr_6 = outerDependence.getExpr();
@@ -222,27 +245,40 @@ public class RaiseDependenceTest {
     Assert.assertEquals(2, updatedCase.getExprs().size());
     AlphaExpression _get_2 = updatedCase.getExprs().get(0);
     Assert.assertTrue((_get_2 instanceof DependenceExpression));
-    AlphaExpression _get_3 = updatedCase.getExprs().get(1);
-    Assert.assertTrue((_get_3 instanceof DependenceExpression));
-    AlphaExpression _get_4 = updatedCase.getExprs().get(0);
-    final DependenceExpression updatedDep1 = ((DependenceExpression) _get_4);
-    AlphaExpression _get_5 = updatedCase.getExprs().get(1);
-    final DependenceExpression updatedDep2 = ((DependenceExpression) _get_5);
+    AlphaExpression _get_3 = updatedCase.getExprs().get(0);
+    final DependenceExpression updatedDep1 = ((DependenceExpression) _get_3);
+    final ISLMultiAff f1Prime = updatedDep1.getFunction();
     AlphaExpression _expr_7 = updatedDep1.getExpr();
     Assert.assertTrue((_expr_7 instanceof RestrictExpression));
     AlphaExpression _expr_8 = updatedDep1.getExpr();
     final RestrictExpression updatedRestrict1 = ((RestrictExpression) _expr_8);
-    AlphaExpression _expr_9 = updatedDep2.getExpr();
-    final RestrictExpression updatedRestrict2 = ((RestrictExpression) _expr_9);
     final ISLSet d1Prime = updatedRestrict1.getRestrictDomain();
+    AlphaExpression _expr_9 = updatedRestrict1.getExpr();
+    Assert.assertTrue((_expr_9 instanceof DependenceExpression));
+    AlphaExpression _expr_10 = updatedRestrict1.getExpr();
+    final DependenceExpression innermostDep1 = ((DependenceExpression) _expr_10);
+    final ISLMultiAff f1Prime2 = innermostDep1.getFunction();
+    AlphaExpression _get_4 = updatedCase.getExprs().get(1);
+    Assert.assertTrue((_get_4 instanceof DependenceExpression));
+    AlphaExpression _get_5 = updatedCase.getExprs().get(1);
+    final DependenceExpression updatedDep2 = ((DependenceExpression) _get_5);
+    final ISLMultiAff f2Prime = updatedDep2.getFunction();
+    AlphaExpression _expr_11 = updatedDep2.getExpr();
+    Assert.assertTrue((_expr_11 instanceof RestrictExpression));
+    AlphaExpression _expr_12 = updatedDep2.getExpr();
+    final RestrictExpression updatedRestrict2 = ((RestrictExpression) _expr_12);
     final ISLSet d2Prime = updatedRestrict2.getRestrictDomain();
-    final ISLMultiAff fPrime = outerDependence.getFunction().copy();
-    final ISLMultiAff f1Prime = updatedDep1.getFunction().copy();
-    final ISLMultiAff f2Prime = updatedDep2.getFunction().copy();
-    Assert.assertTrue(d1Prime.isEqual(d1.apply(f1.copy().toMap())));
-    Assert.assertTrue(d2Prime.isEqual(d2.apply(f2.copy().toMap())));
-    Assert.assertTrue(f1.isPlainEqual(f1Prime.pullback(fPrime.copy())));
-    Assert.assertTrue(f2.isPlainEqual(f2Prime.pullback(fPrime)));
+    AlphaExpression _expr_13 = updatedRestrict2.getExpr();
+    Assert.assertTrue((_expr_13 instanceof DependenceExpression));
+    AlphaExpression _expr_14 = updatedRestrict2.getExpr();
+    final DependenceExpression innermostDep2 = ((DependenceExpression) _expr_14);
+    final ISLMultiAff f2Prime2 = innermostDep2.getFunction();
+    final ISLMultiAff fPrimeAtF1Prime = f1Prime.copy().pullback(fPrime.copy());
+    Assert.assertTrue(f1.isPlainEqual(f1Prime2.pullback(fPrimeAtF1Prime.copy())));
+    final ISLMultiAff fPrimeAtF2Prime = f2Prime.copy().pullback(fPrime.copy());
+    Assert.assertTrue(f2.isPlainEqual(f2Prime2.pullback(fPrimeAtF2Prime.copy())));
+    Assert.assertTrue(d1.isEqual(d1Prime.preimage(fPrimeAtF1Prime)));
+    Assert.assertTrue(d2.isEqual(d2Prime.preimage(fPrimeAtF2Prime)));
   }
 
   @Test
@@ -445,5 +481,106 @@ public class RaiseDependenceTest {
         Assert.assertTrue(expected.isPlainEqual(actual));
       }
     }
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test02() {
+    RaiseDependenceTest.normalizeTest("wrapVariableExpression_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test03() {
+    RaiseDependenceTest.normalizeTest("wrapVariableExpression_02", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test04() {
+    RaiseDependenceTest.normalizeTest("wrapIndexExpression_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test05() {
+    RaiseDependenceTest.normalizeTest("wrapIndexExpression_02", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test06() {
+    RaiseDependenceTest.normalizeTest("nestedDependenceFunction_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test07() {
+    RaiseDependenceTest.normalizeTest("restrictExpression_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test08() {
+    RaiseDependenceTest.normalizeTest("autoRestrictExpression_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test09() {
+    RaiseDependenceTest.normalizeTest("autoRestrictExpression_02", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test10() {
+    RaiseDependenceTest.normalizeTest("unaryExpression_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test11() {
+    RaiseDependenceTest.normalizeTest("simpleBinaryExpression_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test12() {
+    RaiseDependenceTest.normalizeTest("binaryExpressionBecomesNested_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test13() {
+    RaiseDependenceTest.normalizeTest("binaryExpressionBecomesNested_02", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test14() {
+    RaiseDependenceTest.normalizeTest("binaryExpressionBecomesNested_03", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test15() {
+    RaiseDependenceTest.normalizeTest("binaryExpressionBecomesNested_04", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test16() {
+    RaiseDependenceTest.normalizeTest("multiArgTest_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test17() {
+    RaiseDependenceTest.normalizeTest("caseTest_01", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test18() {
+    RaiseDependenceTest.normalizeTest("prefixScan", "X");
+  }
+
+  /**
+   * Used by several tests to ensure that the system can be normalized,
+   * dependence raising can be applied, and then normalized again
+   * to recreate the original normalization.
+   */
+  public static void normalizeTest(final String systemName, final String equationName) {
+    final StandardEquation equation = RaiseDependenceTest.getEquation(systemName, equationName);
+    LiftAutoRestrict.apply(equation);
+    Normalize.apply(equation);
+    final String expected = AShow.print(equation);
+    RaiseDependence.apply(equation);
+    Normalize.apply(equation);
+    final String actual = AShow.print(equation);
+    Assert.assertEquals(expected, actual);
   }
 }

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/RaiseDependenceTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/RaiseDependenceTest.java
@@ -9,6 +9,7 @@ import alpha.model.BinaryExpression;
 import alpha.model.CaseExpression;
 import alpha.model.ConstantExpression;
 import alpha.model.DependenceExpression;
+import alpha.model.ExternalMultiArgExpression;
 import alpha.model.IndexExpression;
 import alpha.model.MultiArgExpression;
 import alpha.model.RestrictExpression;
@@ -438,6 +439,42 @@ public class RaiseDependenceTest {
   }
 
   @Test
+  public void externalFunction_01() {
+    final StandardEquation equation = RaiseDependenceTest.getEquation("externalFunctionTest_01", "X");
+    AlphaExpression _expr = equation.getExpr();
+    final ExternalMultiArgExpression external = ((ExternalMultiArgExpression) _expr);
+    AlphaExpression _get = external.getExprs().get(0);
+    final IndexExpression index1 = ((IndexExpression) _get);
+    final ISLMultiAff f1 = index1.getFunction();
+    AlphaExpression _get_1 = external.getExprs().get(1);
+    final IndexExpression index2 = ((IndexExpression) _get_1);
+    final ISLMultiAff f2 = index2.getFunction();
+    RaiseDependence.apply(equation.getExpr());
+    AlphaExpression _expr_1 = equation.getExpr();
+    Assert.assertTrue((_expr_1 instanceof DependenceExpression));
+    AlphaExpression _expr_2 = equation.getExpr();
+    final DependenceExpression topExpression = ((DependenceExpression) _expr_2);
+    final ISLMultiAff fPrime = topExpression.getFunction();
+    AlphaExpression _expr_3 = topExpression.getExpr();
+    Assert.assertTrue((_expr_3 instanceof ExternalMultiArgExpression));
+    AlphaExpression _expr_4 = topExpression.getExpr();
+    final ExternalMultiArgExpression updatedExternal = ((ExternalMultiArgExpression) _expr_4);
+    Assert.assertEquals(2, updatedExternal.getExprs().size());
+    AlphaExpression _get_2 = updatedExternal.getExprs().get(0);
+    Assert.assertTrue((_get_2 instanceof DependenceExpression));
+    AlphaExpression _get_3 = updatedExternal.getExprs().get(0);
+    final DependenceExpression dependence1 = ((DependenceExpression) _get_3);
+    final ISLMultiAff f1Prime = dependence1.getFunction();
+    AlphaExpression _get_4 = updatedExternal.getExprs().get(1);
+    Assert.assertTrue((_get_4 instanceof DependenceExpression));
+    AlphaExpression _get_5 = updatedExternal.getExprs().get(1);
+    final DependenceExpression dependence2 = ((DependenceExpression) _get_5);
+    final ISLMultiAff f2Prime = dependence2.getFunction();
+    Assert.assertTrue(f1.isPlainEqual(f1Prime.pullback(fPrime.copy())));
+    Assert.assertTrue(f2.isPlainEqual(f2Prime.pullback(fPrime)));
+  }
+
+  @Test
   public void caseTest_01() {
     final StandardEquation equation = RaiseDependenceTest.getEquation("caseTest_01", "X");
     AlphaExpression _expr = equation.getExpr();
@@ -566,6 +603,11 @@ public class RaiseDependenceTest {
   @Test
   public void normalizeUndoesRaising_Test18() {
     RaiseDependenceTest.normalizeTest("prefixScan", "X");
+  }
+
+  @Test
+  public void normalizeUndoesRaising_Test19() {
+    RaiseDependenceTest.normalizeTest("externalFunctionTest_01", "X");
   }
 
   /**

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/RaiseDependenceTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/RaiseDependenceTest.java
@@ -521,6 +521,11 @@ public class RaiseDependenceTest {
   }
 
   @Test
+  public void normalizeUndoesRaising_Test01() {
+    RaiseDependenceTest.normalizeTest("wrapConstantExpression_01", "X");
+  }
+
+  @Test
   public void normalizeUndoesRaising_Test02() {
     RaiseDependenceTest.normalizeTest("wrapVariableExpression_01", "X");
   }


### PR DESCRIPTION
The previous iteration of the rule appeared to be the inverse of the associated normalization rule, but was not. Instead, information about the restriction domain was being lost in some cases, resulting in incorrect programs. This was most easily seen when applying dependence raising to a prefix scan equation. A test for this was added to ensure this scenario doesn't occur again.