### PR TITLE
Allow for hoisting raised dependence expression out of reductions

### DIFF
--- a/bundles/alpha.model/src/alpha/model/transformation/RaiseDependence.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/RaiseDependence.xtend
@@ -452,6 +452,7 @@ class RaiseDependence extends AbstractAlphaCompleteVisitor {
 		de.expr = ve
 		
 		// Recompute context domain
+		AlphaInternalStateConstructor.recomputeContextDomain(eq)
 		AlphaInternalStateConstructor.recomputeContextDomain(re)
 	}
 	def dispatch reduceExpressionRules(ReduceExpression re, AlphaExpression ae) {

--- a/bundles/alpha.model/src/alpha/model/transformation/RaiseDependence.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/RaiseDependence.xtend
@@ -89,7 +89,7 @@ import static extension fr.irisa.cairn.jnimap.isl.ISLSpace.idMapDimFromSetDim
  * Reduce Expressions:
  *     The current implementation does not pull dependence expressions out of reduce expressions.
  *     However, the child of any raised dependence expressions in reduction bodies may be separated
- *     into a new variable. This is controlled by hoistFromReduce flag in apply. If hoistFromReduce
+ *     into a new variable. This is controlled by the hoistFromReduce flag in apply. If hoistFromReduce
  *     is passed as true, then the following rule is applied.
  * 
  *     reduce(op, f, g@E) goes to reduce(op, f, g@V) where V is a new local variable defined as V=E
@@ -100,13 +100,10 @@ class RaiseDependence extends AbstractAlphaCompleteVisitor {
 	 *  separate equation. This flag controls when to do this. See outReduceExpression
 	 *  and reduceExpressionRules.
 	 */
-	protected boolean hoistFromReduce = false
+	val boolean hoistFromReduce
 	
 	/** Protected constructor to restrict access to the instance methods. */
-	protected new() {}
-	
 	protected new(boolean hoistFromReduce) {
-		this()
 		this.hoistFromReduce = hoistFromReduce
 	}
 	
@@ -418,6 +415,10 @@ class RaiseDependence extends AbstractAlphaCompleteVisitor {
 		// Finally, update the context domains for the entire subtree rooted at the wrapping dependence.
 		AlphaInternalStateConstructor.recomputeContextDomain(wrappingDependence)
 	}
+	
+	////////////////////////////////////////////////////////////
+	// Reduce Expressions
+	////////////////////////////////////////////////////////////
 	
 	/**
 	 * Separate the child of a top level dependence expression in the reduction body if hoisting

--- a/bundles/alpha.model/src/alpha/model/transformation/RaiseDependence.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/RaiseDependence.xtend
@@ -11,23 +11,31 @@ import alpha.model.ConstantExpression
 import alpha.model.DependenceExpression
 import alpha.model.IndexExpression
 import alpha.model.MultiArgExpression
+import alpha.model.ReduceExpression
 import alpha.model.RestrictExpression
+import alpha.model.StandardEquation
 import alpha.model.UnaryExpression
 import alpha.model.VariableExpression
 import alpha.model.util.AbstractAlphaCompleteVisitor
 import org.eclipse.emf.ecore.util.EcoreUtil
+
+import static alpha.model.factory.AlphaUserFactory.createStandardEquation
+import static alpha.model.factory.AlphaUserFactory.createVariable
+import static alpha.model.factory.AlphaUserFactory.createVariableExpression
 
 import static extension alpha.model.factory.AlphaUserFactory.createDependenceExpression
 import static extension alpha.model.factory.AlphaUserFactory.createIndexExpression
 import static extension alpha.model.factory.AlphaUserFactory.createJNIDomain
 import static extension alpha.model.factory.AlphaUserFactory.createJNIFunction
 import static extension alpha.model.util.AffineFactorizer.factorizeExpressions
+import static extension alpha.model.util.AlphaUtil.getContainerEquation
+import static extension alpha.model.util.AlphaUtil.getContainerSystem
+import static extension alpha.model.util.AlphaUtil.getContainerSystemBody
 import static extension alpha.model.util.CommonExtensions.toArrayList
 import static extension alpha.model.util.CommonExtensions.toHashMap
 import static extension fr.irisa.cairn.jnimap.isl.ISLMultiAff.buildIdentity
 import static extension fr.irisa.cairn.jnimap.isl.ISLMultiAff.buildZero
 import static extension fr.irisa.cairn.jnimap.isl.ISLSpace.idMapDimFromSetDim
-import alpha.model.AlphaCompleteVisitable
 
 /**
  * Raises up dependence functions through the AST of a given expression.
@@ -77,19 +85,47 @@ import alpha.model.AlphaCompleteVisitable
  *     ((f1 @ E1) op (f2 @ E2)) goes to ((f')@((f1' @ E1) op (f2' @ E2))) where f1 = f' @ f1' and f2 = f' @ f2'
  *     op(f1@E1, f2@E2, ...) goes to (f')@ op(f1'@E1, f2'@E2, ...) where fn = f' @ fn'
  *     case {f1@E1, f2@E2, ...} goes to (f')@ case{f1'@E1, f2'@E2, ...} where fn = f' @ fn'
+ * 
+ * Reduce Expressions:
+ *     The current implementation does not pull dependence expressions out of reduce expressions.
+ *     However, the child of any raised dependence expressions in reduction bodies may be separated
+ *     into a new variable. This is controlled by hoistFromReduce flag in apply. If hoistFromReduce
+ *     is passed as true, then the following rule is applied.
+ * 
+ *     reduce(op, f, g@E) goes to reduce(op, f, g@V) where V is a new local variable defined as V=E
  */
 class RaiseDependence extends AbstractAlphaCompleteVisitor {
+	
+	/** Dependence expressions raised in the body of a reduction may be hoisted into a  
+	 *  separate equation. This flag controls when to do this. See outReduceExpression
+	 *  and reduceExpressionRules.
+	 */
+	protected boolean hoistFromReduce = false
+	
 	/** Protected constructor to restrict access to the instance methods. */
 	protected new() {}
 	
+	protected new(boolean hoistFromReduce) {
+		this()
+		this.hoistFromReduce = hoistFromReduce
+	}
+	
 	/** Applies dependence raising to the AST of the given visitable expression. */
 	static def apply(AlphaExpressionVisitable visitable) {
-		new RaiseDependence().accept(visitable)
+		apply(visitable, false)
+	}
+	
+	static def apply(AlphaExpressionVisitable visitable, boolean hoistFromReduce) {
+		new RaiseDependence(hoistFromReduce).accept(visitable)
 	}
 	
 	/** Applies dependence raising to the AST of the given visitable object (system). */
 	static def void apply(AlphaVisitable av) {
-		new RaiseDependence().accept(av)
+		apply(av, false)
+	}
+	
+	static def void apply(AlphaVisitable av, boolean hoistFromReduce) {
+		new RaiseDependence(hoistFromReduce).accept(av)
 	}
 	
 	////////////////////////////////////////////////////////////
@@ -381,5 +417,44 @@ class RaiseDependence extends AbstractAlphaCompleteVisitor {
 		
 		// Finally, update the context domains for the entire subtree rooted at the wrapping dependence.
 		AlphaInternalStateConstructor.recomputeContextDomain(wrappingDependence)
+	}
+	
+	/**
+	 * Separate the child of a top level dependence expression in the reduction body if hoisting
+	 * is specified.
+	 */
+	override outReduceExpression(ReduceExpression re) {
+		if (hoistFromReduce) {
+			reduceExpressionRules(re, re.body)
+		}
+	}
+	
+	/**
+	 * Pull out a common factor from dependence expressions within a case expression.
+	 * 
+	 * From:  reduce(op, f, g@E)
+	 * To:    reduce(op, f, g@V)
+	 * Where: V is a new local variable, V=E, defined as over the context domain of E
+	 */
+	def dispatch reduceExpressionRules(ReduceExpression re, DependenceExpression de) {
+		// Add a new local variable V
+		val domain = de.expr.contextDomain.computeDivs
+		val varName = (re.getContainerEquation as StandardEquation).variable.name
+		val variable = createVariable(varName + '_body', domain.copy)
+		re.getContainerSystem.locals += variable
+		
+		// Add an equation for V=E
+		val eq = createStandardEquation(variable, de.expr)
+		re.getContainerSystemBody.equations += eq
+		
+		// Reference the variable in de.expr
+		val ve = createVariableExpression(variable)
+		de.expr = ve
+		
+		// Recompute context domain
+		AlphaInternalStateConstructor.recomputeContextDomain(re)
+	}
+	def dispatch reduceExpressionRules(ReduceExpression re, AlphaExpression ae) {
+		// do nothing
 	}
 }

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/RaiseDependence.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/RaiseDependence.java
@@ -98,7 +98,7 @@ import org.eclipse.xtext.xbase.lib.Pair;
  * Reduce Expressions:
  *     The current implementation does not pull dependence expressions out of reduce expressions.
  *     However, the child of any raised dependence expressions in reduction bodies may be separated
- *     into a new variable. This is controlled by hoistFromReduce flag in apply. If hoistFromReduce
+ *     into a new variable. This is controlled by the hoistFromReduce flag in apply. If hoistFromReduce
  *     is passed as true, then the following rule is applied.
  * 
  *     reduce(op, f, g@E) goes to reduce(op, f, g@V) where V is a new local variable defined as V=E
@@ -110,16 +110,12 @@ public class RaiseDependence extends AbstractAlphaCompleteVisitor {
    *  separate equation. This flag controls when to do this. See outReduceExpression
    *  and reduceExpressionRules.
    */
-  protected boolean hoistFromReduce = false;
+  private final boolean hoistFromReduce;
 
   /**
    * Protected constructor to restrict access to the instance methods.
    */
-  protected RaiseDependence() {
-  }
-
   protected RaiseDependence(final boolean hoistFromReduce) {
-    this();
     this.hoistFromReduce = hoistFromReduce;
   }
 

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/RaiseDependence.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/RaiseDependence.java
@@ -472,6 +472,7 @@ public class RaiseDependence extends AbstractAlphaCompleteVisitor {
       _equations.add(eq);
       final VariableExpression ve = AlphaUserFactory.createVariableExpression(variable);
       de.setExpr(ve);
+      AlphaInternalStateConstructor.recomputeContextDomain(eq);
       _xblockexpression = AlphaInternalStateConstructor.recomputeContextDomain(re);
     }
     return _xblockexpression;

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/RaiseDependence.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/RaiseDependence.java
@@ -9,16 +9,21 @@ import alpha.model.BinaryExpression;
 import alpha.model.CaseExpression;
 import alpha.model.ConstantExpression;
 import alpha.model.DependenceExpression;
+import alpha.model.Equation;
 import alpha.model.IndexExpression;
 import alpha.model.JNIFunction;
 import alpha.model.MultiArgExpression;
+import alpha.model.ReduceExpression;
 import alpha.model.RestrictExpression;
+import alpha.model.StandardEquation;
 import alpha.model.UnaryExpression;
+import alpha.model.Variable;
 import alpha.model.VariableExpression;
 import alpha.model.factory.AlphaUserFactory;
 import alpha.model.issue.AlphaIssue;
 import alpha.model.util.AbstractAlphaCompleteVisitor;
 import alpha.model.util.AffineFactorizer;
+import alpha.model.util.AlphaUtil;
 import alpha.model.util.CommonExtensions;
 import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
 import fr.irisa.cairn.jnimap.isl.ISLConstraint;
@@ -89,27 +94,55 @@ import org.eclipse.xtext.xbase.lib.Pair;
  *     ((f1 @ E1) op (f2 @ E2)) goes to ((f')@((f1' @ E1) op (f2' @ E2))) where f1 = f' @ f1' and f2 = f' @ f2'
  *     op(f1@E1, f2@E2, ...) goes to (f')@ op(f1'@E1, f2'@E2, ...) where fn = f' @ fn'
  *     case {f1@E1, f2@E2, ...} goes to (f')@ case{f1'@E1, f2'@E2, ...} where fn = f' @ fn'
+ * 
+ * Reduce Expressions:
+ *     The current implementation does not pull dependence expressions out of reduce expressions.
+ *     However, the child of any raised dependence expressions in reduction bodies may be separated
+ *     into a new variable. This is controlled by hoistFromReduce flag in apply. If hoistFromReduce
+ *     is passed as true, then the following rule is applied.
+ * 
+ *     reduce(op, f, g@E) goes to reduce(op, f, g@V) where V is a new local variable defined as V=E
  */
 @SuppressWarnings("all")
 public class RaiseDependence extends AbstractAlphaCompleteVisitor {
+  /**
+   * Dependence expressions raised in the body of a reduction may be hoisted into a
+   *  separate equation. This flag controls when to do this. See outReduceExpression
+   *  and reduceExpressionRules.
+   */
+  protected boolean hoistFromReduce = false;
+
   /**
    * Protected constructor to restrict access to the instance methods.
    */
   protected RaiseDependence() {
   }
 
+  protected RaiseDependence(final boolean hoistFromReduce) {
+    this();
+    this.hoistFromReduce = hoistFromReduce;
+  }
+
   /**
    * Applies dependence raising to the AST of the given visitable expression.
    */
   public static void apply(final AlphaExpressionVisitable visitable) {
-    new RaiseDependence().accept(visitable);
+    RaiseDependence.apply(visitable, false);
+  }
+
+  public static void apply(final AlphaExpressionVisitable visitable, final boolean hoistFromReduce) {
+    new RaiseDependence(hoistFromReduce).accept(visitable);
   }
 
   /**
    * Applies dependence raising to the AST of the given visitable object (system).
    */
   public static void apply(final AlphaVisitable av) {
-    new RaiseDependence().accept(av);
+    RaiseDependence.apply(av, false);
+  }
+
+  public static void apply(final AlphaVisitable av, final boolean hoistFromReduce) {
+    new RaiseDependence(hoistFromReduce).accept(av);
   }
 
   /**
@@ -407,6 +440,47 @@ public class RaiseDependence extends AbstractAlphaCompleteVisitor {
     return _xblockexpression;
   }
 
+  /**
+   * Separate the child of a top level dependence expression in the reduction body if hoisting
+   * is specified.
+   */
+  @Override
+  public void outReduceExpression(final ReduceExpression re) {
+    if (this.hoistFromReduce) {
+      this.reduceExpressionRules(re, re.getBody());
+    }
+  }
+
+  /**
+   * Pull out a common factor from dependence expressions within a case expression.
+   * 
+   * From:  reduce(op, f, g@E)
+   * To:    reduce(op, f, g@V)
+   * Where: V is a new local variable, V=E, defined as over the context domain of E
+   */
+  protected List<AlphaIssue> _reduceExpressionRules(final ReduceExpression re, final DependenceExpression de) {
+    List<AlphaIssue> _xblockexpression = null;
+    {
+      final ISLSet domain = de.getExpr().getContextDomain().computeDivs();
+      Equation _containerEquation = AlphaUtil.getContainerEquation(re);
+      final String varName = ((StandardEquation) _containerEquation).getVariable().getName();
+      final Variable variable = AlphaUserFactory.createVariable((varName + "_body"), domain.copy());
+      EList<Variable> _locals = AlphaUtil.getContainerSystem(re).getLocals();
+      _locals.add(variable);
+      final StandardEquation eq = AlphaUserFactory.createStandardEquation(variable, de.getExpr());
+      EList<Equation> _equations = AlphaUtil.getContainerSystemBody(re).getEquations();
+      _equations.add(eq);
+      final VariableExpression ve = AlphaUserFactory.createVariableExpression(variable);
+      de.setExpr(ve);
+      _xblockexpression = AlphaInternalStateConstructor.recomputeContextDomain(re);
+    }
+    return _xblockexpression;
+  }
+
+  protected List<AlphaIssue> _reduceExpressionRules(final ReduceExpression re, final AlphaExpression ae) {
+    return null;
+  }
+
   protected List<AlphaIssue> dependenceExpressionRule(final DependenceExpression outerDe, final AlphaExpression innerDe) {
     if (innerDe instanceof DependenceExpression) {
       return _dependenceExpressionRule(outerDe, (DependenceExpression)innerDe);
@@ -450,6 +524,17 @@ public class RaiseDependence extends AbstractAlphaCompleteVisitor {
     } else {
       throw new IllegalArgumentException("Unhandled parameter types: " +
         Arrays.<Object>asList(be, left, right).toString());
+    }
+  }
+
+  public List<AlphaIssue> reduceExpressionRules(final ReduceExpression re, final AlphaExpression de) {
+    if (de instanceof DependenceExpression) {
+      return _reduceExpressionRules(re, (DependenceExpression)de);
+    } else if (de != null) {
+      return _reduceExpressionRules(re, de);
+    } else {
+      throw new IllegalArgumentException("Unhandled parameter types: " +
+        Arrays.<Object>asList(re, de).toString());
     }
   }
 }


### PR DESCRIPTION
After RaiseDependence is called, reduce expressions will be of the form: `reduce(op, f, g@E)`. The expression E can be arbitrarily complex and there are times when we would like to separate it into a new local variable. This will be needed for the implementation of the optimal simplifying reductions algorithm.

In our original proof-of-concepts, we had a separate class called RaiseDependenceAndIsolate which extended RaiseDependence and did the hoisting. A separate class is probably overkill since it only requires a single new dispatch method for reduction nodes. This PR simply overloads the `apply` method in RaiseDependence with a new flag called `hoistFromReduce` to indicate when this separation should be done.

Now when `RaiseDependence.apply(visitable, true)` is called, reduce expressions of the form…
```
locals
    ...
let
    ...
    X = reduce(op, f, g@E);
```
…are transformed into…
```
locals
    ...
    V = context domain of E
let
    ...
    X = reduce(op, f, g@V);
    V = E;
```

This addresses issue #31.