### PR TITLE
Standardize Names Transformation and Copy AST

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
         org.junit.runner.JUnitCore alpha.model.tests.transformations.SimplifyExpressionsTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.SimplifyingReductionsTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.SplitUnionIntoCaseTest
+        org.junit.runner.JUnitCore alpha.model.tests.transformations.StandardizeNamesTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.SubstituteByDefTest
         org.junit.runner.JUnitCore alpha.model.tests.util.AffineFactorizerTest
         org.junit.runner.JUnitCore alpha.model.tests.util.FaceLatticeTest

--- a/bundles/alpha.model/src/alpha/model/transformation/StandardizeNames.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/StandardizeNames.xtend
@@ -14,6 +14,8 @@ import java.util.List
 import static extension alpha.model.factory.AlphaUserFactory.createJNIDomain
 import static extension alpha.model.factory.AlphaUserFactory.createJNIFunction
 import static extension alpha.model.util.AlphaUtil.renameOutputs
+import alpha.model.IndexExpression
+import alpha.model.ReduceExpression
 
 /**
  * Standardizes the names of indices in most context domains,
@@ -80,6 +82,11 @@ class StandardizeNames extends AbstractAlphaCompleteVisitor {
 		return expr.function.space.outputNames
 	}
 	
+	/** Gets the index names to use from a parent reduce expression. */
+	def protected static dispatch getIndexNames(ReduceExpression expr) {
+		return expr.projection.space.outputNames
+	}
+	
 	/** Gets the index names to use from a parent expression. */
 	def protected static dispatch getIndexNames(AlphaExpression expr) {
 		return expr.contextDomain.indexNames
@@ -132,6 +139,42 @@ class StandardizeNames extends AbstractAlphaCompleteVisitor {
 		// context and expression domains, but the output dimensions are set to default names.
 		expr.functionExpr = AlphaUtil
 			.renameIndices(expr.function, indexNames)
+			.renameOutputs
+			.createJNIFunction
+	}
+	
+	/**
+	 * Renames the indices of the context domain and expression domain of the expression.
+	 * Also renames the inputs and outputs of the index function.
+	 */
+	override inIndexExpression(IndexExpression expr) {
+		val indexNames = expr.eContainer.getIndexNames
+		
+		expr.contextDomain = expr.contextDomain.renameIndices(indexNames)
+		expr.expressionDomain = expr.expressionDomain.renameIndices(indexNames)
+		
+		// The inputs to the index function are renamed to be the same as the
+		// context and expression domains, but the output dimensions are set to default names.
+		expr.functionExpr = AlphaUtil
+			.renameIndices(expr.function, indexNames)
+			.renameOutputs
+			.createJNIFunction
+	}
+	
+	/**
+	 * Renames the indices of the context domain and expression domain of the expression.
+	 * Also renames the inputs and outputs of the projection function.
+	 */
+	override inReduceExpression(ReduceExpression expr) {
+		val indexNames = expr.eContainer.getIndexNames
+		
+		expr.contextDomain = expr.contextDomain.renameIndices(indexNames)
+		expr.expressionDomain = expr.expressionDomain.renameIndices(indexNames)
+		
+		// The inputs to the projection function are renamed to be the same as the
+		// context and expression domains, but the output dimensions are set to default names.
+		expr.projectionExpr = AlphaUtil
+			.renameIndices(expr.projection, indexNames)
 			.renameOutputs
 			.createJNIFunction
 	}

--- a/bundles/alpha.model/src/alpha/model/transformation/StandardizeNames.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/StandardizeNames.xtend
@@ -86,7 +86,7 @@ class StandardizeNames extends AbstractAlphaCompleteVisitor {
 	
 	/** Gets the index names to use from a parent reduce expression. */
 	def protected static dispatch getIndexNames(ReduceExpression expr) {
-		return expr.projection.space.outputNames
+		return expr.projection.space.inputNames
 	}
 	
 	/** Gets the index names to use from a parent expression. */
@@ -111,7 +111,7 @@ class StandardizeNames extends AbstractAlphaCompleteVisitor {
 	 */
 	def protected static renameOutputs(ISLMultiAff multiAff) {
 		val outputNames = (0 ..< multiAff.nbOutputs).map[getOutputName(multiAff, it)].toArrayList
-		return AlphaUtil.renameOutputs(multiAff, outputNames)
+		return AlphaUtil.renameFirstOutputs(multiAff, outputNames)
 	}
 	
 	/** Gets the name to use for a specific output of the given multi-affine expression. */
@@ -221,7 +221,7 @@ class StandardizeNames extends AbstractAlphaCompleteVisitor {
 		// The inputs to the projection function are renamed to be the same as the
 		// context and expression domains, but the output dimensions are set to default names.
 		expr.projectionExpr = AlphaUtil
-			.renameIndices(expr.projection, indexNames)
+			.renameFirstIndices(expr.projection, indexNames)
 			.renameOutputs
 			.createJNIFunction
 	}

--- a/bundles/alpha.model/src/alpha/model/transformation/StandardizeNames.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/StandardizeNames.xtend
@@ -1,0 +1,138 @@
+package alpha.model.transformation
+
+import alpha.model.AlphaExpression
+import alpha.model.AlphaExpressionVisitable
+import alpha.model.AlphaVisitable
+import alpha.model.DependenceExpression
+import alpha.model.RestrictExpression
+import alpha.model.StandardEquation
+import alpha.model.Variable
+import alpha.model.util.AbstractAlphaCompleteVisitor
+import alpha.model.util.AlphaUtil
+import java.util.List
+
+import static extension alpha.model.factory.AlphaUserFactory.createJNIDomain
+import static extension alpha.model.factory.AlphaUserFactory.createJNIFunction
+import static extension alpha.model.util.AlphaUtil.renameOutputs
+
+/**
+ * Standardizes the names of indices in most context domains,
+ * expression domains, dependence functions, and restrict domains
+ * throughout the provided AST (or sub-tree).
+ * 
+ * Within all of these, input dimensions are renamed to "i0", "i1", etc.
+ * based on their position in the space.
+ */
+class StandardizeNames extends AbstractAlphaCompleteVisitor {
+	
+	////////////////////////////////////////////////////////////
+	// Entry Points
+	////////////////////////////////////////////////////////////
+	
+	/** Protected constructor to force "apply" to be the entry point. */
+	protected new() {}
+	
+	/** Applies name standardization to an Alpha expression. */
+	def static apply(AlphaExpressionVisitable visitable) {
+		new StandardizeNames().accept(visitable)
+	}
+	
+	/** Applies name standardization to an Alpha system, equation, etc. */
+	def static apply(AlphaVisitable visitable) {
+		new StandardizeNames().accept(visitable)
+	}
+	
+	
+	////////////////////////////////////////////////////////////
+	// Get Index Names
+	////////////////////////////////////////////////////////////
+	
+	/** Checks whether the given list of names are valid index names for the given variable. */
+	def protected static areValidNames(List<String> indexNames, Variable variable) {
+		// For a list of index names to be valid, it can't be null
+		// and must have the same number of names as the variable has indices.
+		return indexNames !== null
+			&& indexNames.size == variable.domain.nbIndices
+	}
+	
+	/** Gets the index names to use from a parent equation. */
+	def protected static dispatch getIndexNames(StandardEquation eq) {
+		val variable = eq.variable
+		
+		// If the equation has index names (and they're valid), use those.
+		val equationNames = eq.indexNames
+		if (equationNames.areValidNames(variable)) {
+			return equationNames
+		}
+		
+		// Otherwise, try to use the names from the variable's domain.
+		val variableNames = variable.domain.indexNames
+		if (variableNames.areValidNames(variable)) {
+			return variableNames
+		}
+		
+		// As a last resort, use some default names.
+		return AlphaUtil.defaultDimNames(variable.domain)
+	}
+	
+	/** Gets the index names to use from a parent dependence expression. */
+	def protected static dispatch getIndexNames(DependenceExpression expr) {
+		return expr.function.space.outputNames
+	}
+	
+	/** Gets the index names to use from a parent expression. */
+	def protected static dispatch getIndexNames(AlphaExpression expr) {
+		return expr.contextDomain.indexNames
+	}
+	
+	/** Default rule if none of the other cases matched. */
+	def protected static dispatch getIndexNames(Object obj) {
+		throw new Exception("Cannot get the index names to use from the given parent.")
+	}
+	
+	
+	////////////////////////////////////////////////////////////
+	// Name Standardization Rules
+	////////////////////////////////////////////////////////////
+	
+	/** Renames the indices of the context domain and expression domain of the expression. */
+	override inAlphaExpression(AlphaExpression expr) {
+		val indexNames = expr.eContainer.getIndexNames
+		
+		expr.contextDomain = expr.contextDomain.renameIndices(indexNames)
+		expr.expressionDomain = expr.expressionDomain.renameIndices(indexNames)
+	}
+	
+	/**
+	 * Renames the indices of the context domain, expression domain, and restrict domain
+	 * for the restrict expression.
+	 */
+	override inRestrictExpression(RestrictExpression expr) {
+		val indexNames = expr.eContainer.getIndexNames
+		
+		expr.contextDomain = expr.contextDomain.renameIndices(indexNames)
+		expr.expressionDomain = expr.expressionDomain.renameIndices(indexNames)
+		
+		expr.domainExpr = AlphaUtil
+			.renameIndices(expr.restrictDomain, indexNames)
+			.createJNIDomain
+	}
+	
+	/**
+	 * Renames the indices of the context domain and expression domain of the expression.
+	 * Also renames the inputs and outputs of the dependence function.
+	 */
+	override outDependenceExpression(DependenceExpression expr) {
+		val indexNames = expr.eContainer.getIndexNames
+		
+		expr.contextDomain = expr.contextDomain.renameIndices(indexNames)
+		expr.expressionDomain = expr.expressionDomain.renameIndices(indexNames)
+		
+		// The inputs to the dependence function are renamed to be the same as the
+		// context and expression domains, but the output dimensions are set to default names.
+		expr.functionExpr = AlphaUtil
+			.renameIndices(expr.function, indexNames)
+			.renameOutputs
+			.createJNIFunction
+	}
+}

--- a/bundles/alpha.model/src/alpha/model/transformation/StandardizeNames.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/StandardizeNames.xtend
@@ -122,7 +122,7 @@ class StandardizeNames extends AbstractAlphaCompleteVisitor {
 	 * Renames the indices of the context domain and expression domain of the expression.
 	 * Also renames the inputs and outputs of the dependence function.
 	 */
-	override outDependenceExpression(DependenceExpression expr) {
+	override inDependenceExpression(DependenceExpression expr) {
 		val indexNames = expr.eContainer.getIndexNames
 		
 		expr.contextDomain = expr.contextDomain.renameIndices(indexNames)

--- a/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
@@ -9,31 +9,41 @@ import alpha.model.AlphaSystem
 import alpha.model.AlphaVisitable
 import alpha.model.Equation
 import alpha.model.SystemBody
+import fr.irisa.cairn.jnimap.isl.ISLAff
+import fr.irisa.cairn.jnimap.isl.ISLDimType
 import fr.irisa.cairn.jnimap.isl.ISLErrorException
 import fr.irisa.cairn.jnimap.isl.ISLFactory
-import fr.irisa.cairn.jnimap.isl.JNIISLTools
-import java.util.LinkedList
-import java.util.List
-import java.util.function.Consumer
-import java.util.function.Supplier
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider
-import org.eclipse.xtext.naming.IQualifiedNameProvider
-import fr.irisa.cairn.jnimap.isl.ISLDimType
 import fr.irisa.cairn.jnimap.isl.ISLMap
 import fr.irisa.cairn.jnimap.isl.ISLMultiAff
 import fr.irisa.cairn.jnimap.isl.ISLPWQPolynomial
 import fr.irisa.cairn.jnimap.isl.ISLQPolynomial
 import fr.irisa.cairn.jnimap.isl.ISLSet
 import fr.irisa.cairn.jnimap.isl.ISLUnionMap
-import fr.irisa.cairn.jnimap.isl.ISLAff
+import fr.irisa.cairn.jnimap.isl.JNIISLTools
+import java.util.LinkedList
+import java.util.List
+import java.util.function.Consumer
+import java.util.function.Supplier
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.util.EcoreUtil.Copier
+import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider
+import org.eclipse.xtext.naming.IQualifiedNameProvider
 
 /**
  * Utility methods for analysis and transformation of Alpha programs.
  * 
  */
 class AlphaUtil {
-	
+	/**
+	 * Returns a self-contained copy of the eObject.
+	 */
+	static def <T extends EObject> T copyAE(T eObject) {
+		val Copier copier = new Copier();
+		val EObject result = copier.copy(eObject);
+		copier.copyReferences();
+		val T t = result as T;
+		return t;
+	}
 	
 	/**
 	 * Given a name candidate, ensures that it does not conflict

--- a/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
@@ -296,7 +296,12 @@ class AlphaUtil {
 	static def renameIndices(ISLMultiAff maff, List<String> names) {
 		val n = maff.getNbInputs
 		if (n > names.length) throw new RuntimeException("Need n or more index names to rename n-d space.");
-		return renameFirstIndices(maff, names)
+		var res = maff;
+		for (i : 0..<n) {
+			res = res.setDimName(ISLDimType.isl_dim_in, i, names.get(i))
+		}
+
+		return res
 	}
 	
 	/**
@@ -349,7 +354,7 @@ class AlphaUtil {
 			throw new RuntimeException("Need n or more index names to rename n-d space.")
 		}
 		
-		return renameFirstOutputs(maff, names)
+		return (0..<nbDims).fold(maff, [_maff, dim | _maff.setDimName(ISLDimType.isl_dim_out,  dim, names.get(dim))])
 	}
 	
 	/**

--- a/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
@@ -296,13 +296,18 @@ class AlphaUtil {
 	static def renameIndices(ISLMultiAff maff, List<String> names) {
 		val n = maff.getNbInputs
 		if (n > names.length) throw new RuntimeException("Need n or more index names to rename n-d space.");
-		var res = maff;
-		for (i : 0..<n) {
-			res = res.setDimName(ISLDimType.isl_dim_in, i, names.get(i))
-		}
-			
-		return res
+		return renameFirstIndices(maff, names)
 	}
+	
+	/**
+	 * Renames as many inputs of the given multi-affine expression as possible.
+	 * If more names are given than there are inputs, then all the inputs will be renamed.
+	 */
+	static def renameFirstIndices(ISLMultiAff maff, List<String> names) {
+		val maxIndex = Integer.min(maff.nbOutputs, names.size)
+		return (0..<maxIndex).fold(maff, [_maff, dim | _maff.setDimName(ISLDimType.isl_dim_in, dim, names.get(dim))])
+	}
+	
 	static def renameIndices(ISLPWQPolynomial pwqp, List<String> names) {
 		val n = pwqp.dim(ISLDimType.isl_dim_in)
 		if (n > names.length) throw new RuntimeException("Need n or more index names to rename n-d space.");
@@ -344,7 +349,16 @@ class AlphaUtil {
 			throw new RuntimeException("Need n or more index names to rename n-d space.")
 		}
 		
-		return (0..<nbDims).fold(maff, [_maff, dim | _maff.setDimName(ISLDimType.isl_dim_out,  dim, names.get(dim))])
+		return renameFirstOutputs(maff, names)
+	}
+	
+	/**
+	 * Renames as many outputs of the given multi-affine expression as possible.
+	 * If more names are given than there are outputs, then all the outputs will be renamed.
+	 */
+	static def renameFirstOutputs(ISLMultiAff maff, List<String> names) {
+		val maxIndex = Integer.min(maff.nbOutputs, names.size)
+		return (0..<maxIndex).fold(maff, [_maff, dim | _maff.setDimName(ISLDimType.isl_dim_out, dim, names.get(dim))])
 	}
 	
 	/**

--- a/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
@@ -309,7 +309,7 @@ class AlphaUtil {
 	 * If more names are given than there are inputs, then all the inputs will be renamed.
 	 */
 	static def renameFirstIndices(ISLMultiAff maff, List<String> names) {
-		val maxIndex = Integer.min(maff.nbOutputs, names.size)
+		val maxIndex = Integer.min(maff.nbInputs, names.size)
 		return (0..<maxIndex).fold(maff, [_maff, dim | _maff.setDimName(ISLDimType.isl_dim_in, dim, names.get(dim))])
 	}
 	

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/StandardizeNames.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/StandardizeNames.java
@@ -94,7 +94,7 @@ public class StandardizeNames extends AbstractAlphaCompleteVisitor {
    * Gets the index names to use from a parent reduce expression.
    */
   protected static List<String> _getIndexNames(final ReduceExpression expr) {
-    return expr.getProjection().getSpace().getOutputNames();
+    return expr.getProjection().getSpace().getInputNames();
   }
 
   /**
@@ -126,7 +126,7 @@ public class StandardizeNames extends AbstractAlphaCompleteVisitor {
       return StandardizeNames.getOutputName(multiAff, (it).intValue());
     };
     final ArrayList<String> outputNames = CommonExtensions.<String>toArrayList(IterableExtensions.<Integer, String>map(new ExclusiveRange(0, _nbOutputs, true), _function));
-    return AlphaUtil.renameOutputs(multiAff, outputNames);
+    return AlphaUtil.renameFirstOutputs(multiAff, outputNames);
   }
 
   /**
@@ -218,7 +218,7 @@ public class StandardizeNames extends AbstractAlphaCompleteVisitor {
     final List<String> indexNames = StandardizeNames.getIndexNames(expr.eContainer());
     expr.setContextDomain(expr.getContextDomain().<ISLSet>renameIndices(indexNames));
     expr.setExpressionDomain(expr.getExpressionDomain().<ISLSet>renameIndices(indexNames));
-    expr.setProjectionExpr(AlphaUserFactory.createJNIFunction(StandardizeNames.renameOutputs(AlphaUtil.renameIndices(expr.getProjection(), indexNames))));
+    expr.setProjectionExpr(AlphaUserFactory.createJNIFunction(StandardizeNames.renameOutputs(AlphaUtil.renameFirstIndices(expr.getProjection(), indexNames))));
   }
 
   protected static List<String> getIndexNames(final Object expr) {

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/StandardizeNames.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/StandardizeNames.java
@@ -123,7 +123,7 @@ public class StandardizeNames extends AbstractAlphaCompleteVisitor {
    * Also renames the inputs and outputs of the dependence function.
    */
   @Override
-  public void outDependenceExpression(final DependenceExpression expr) {
+  public void inDependenceExpression(final DependenceExpression expr) {
     final List<String> indexNames = StandardizeNames.getIndexNames(expr.eContainer());
     expr.setContextDomain(expr.getContextDomain().<ISLSet>renameIndices(indexNames));
     expr.setExpressionDomain(expr.getExpressionDomain().<ISLSet>renameIndices(indexNames));

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/StandardizeNames.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/StandardizeNames.java
@@ -1,0 +1,147 @@
+package alpha.model.transformation;
+
+import alpha.model.AlphaExpression;
+import alpha.model.AlphaExpressionVisitable;
+import alpha.model.AlphaVisitable;
+import alpha.model.DependenceExpression;
+import alpha.model.RestrictExpression;
+import alpha.model.StandardEquation;
+import alpha.model.Variable;
+import alpha.model.factory.AlphaUserFactory;
+import alpha.model.util.AbstractAlphaCompleteVisitor;
+import alpha.model.util.AlphaUtil;
+import fr.irisa.cairn.jnimap.isl.ISLSet;
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+
+/**
+ * Standardizes the names of indices in most context domains,
+ * expression domains, dependence functions, and restrict domains
+ * throughout the provided AST (or sub-tree).
+ * 
+ * Within all of these, input dimensions are renamed to "i0", "i1", etc.
+ * based on their position in the space.
+ */
+@SuppressWarnings("all")
+public class StandardizeNames extends AbstractAlphaCompleteVisitor {
+  /**
+   * Protected constructor to force "apply" to be the entry point.
+   */
+  protected StandardizeNames() {
+  }
+
+  /**
+   * Applies name standardization to an Alpha expression.
+   */
+  public static void apply(final AlphaExpressionVisitable visitable) {
+    new StandardizeNames().accept(visitable);
+  }
+
+  /**
+   * Applies name standardization to an Alpha system, equation, etc.
+   */
+  public static void apply(final AlphaVisitable visitable) {
+    new StandardizeNames().accept(visitable);
+  }
+
+  /**
+   * Checks whether the given list of names are valid index names for the given variable.
+   */
+  protected static boolean areValidNames(final List<String> indexNames, final Variable variable) {
+    return ((indexNames != null) && (indexNames.size() == variable.getDomain().getNbIndices()));
+  }
+
+  /**
+   * Gets the index names to use from a parent equation.
+   */
+  protected static List<String> _getIndexNames(final StandardEquation eq) {
+    final Variable variable = eq.getVariable();
+    final EList<String> equationNames = eq.getIndexNames();
+    boolean _areValidNames = StandardizeNames.areValidNames(equationNames, variable);
+    if (_areValidNames) {
+      return equationNames;
+    }
+    final List<String> variableNames = variable.getDomain().getIndexNames();
+    boolean _areValidNames_1 = StandardizeNames.areValidNames(variableNames, variable);
+    if (_areValidNames_1) {
+      return variableNames;
+    }
+    return AlphaUtil.defaultDimNames(variable.getDomain());
+  }
+
+  /**
+   * Gets the index names to use from a parent dependence expression.
+   */
+  protected static List<String> _getIndexNames(final DependenceExpression expr) {
+    return expr.getFunction().getSpace().getOutputNames();
+  }
+
+  /**
+   * Gets the index names to use from a parent expression.
+   */
+  protected static List<String> _getIndexNames(final AlphaExpression expr) {
+    return expr.getContextDomain().getIndexNames();
+  }
+
+  /**
+   * Default rule if none of the other cases matched.
+   */
+  protected static List<String> _getIndexNames(final Object obj) {
+    try {
+      throw new Exception("Cannot get the index names to use from the given parent.");
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+
+  /**
+   * Renames the indices of the context domain and expression domain of the expression.
+   */
+  @Override
+  public void inAlphaExpression(final AlphaExpression expr) {
+    final List<String> indexNames = StandardizeNames.getIndexNames(expr.eContainer());
+    expr.setContextDomain(expr.getContextDomain().<ISLSet>renameIndices(indexNames));
+    expr.setExpressionDomain(expr.getExpressionDomain().<ISLSet>renameIndices(indexNames));
+  }
+
+  /**
+   * Renames the indices of the context domain, expression domain, and restrict domain
+   * for the restrict expression.
+   */
+  @Override
+  public void inRestrictExpression(final RestrictExpression expr) {
+    final List<String> indexNames = StandardizeNames.getIndexNames(expr.eContainer());
+    expr.setContextDomain(expr.getContextDomain().<ISLSet>renameIndices(indexNames));
+    expr.setExpressionDomain(expr.getExpressionDomain().<ISLSet>renameIndices(indexNames));
+    expr.setDomainExpr(AlphaUserFactory.createJNIDomain(AlphaUtil.renameIndices(expr.getRestrictDomain(), indexNames)));
+  }
+
+  /**
+   * Renames the indices of the context domain and expression domain of the expression.
+   * Also renames the inputs and outputs of the dependence function.
+   */
+  @Override
+  public void outDependenceExpression(final DependenceExpression expr) {
+    final List<String> indexNames = StandardizeNames.getIndexNames(expr.eContainer());
+    expr.setContextDomain(expr.getContextDomain().<ISLSet>renameIndices(indexNames));
+    expr.setExpressionDomain(expr.getExpressionDomain().<ISLSet>renameIndices(indexNames));
+    expr.setFunctionExpr(AlphaUserFactory.createJNIFunction(AlphaUtil.renameOutputs(AlphaUtil.renameIndices(expr.getFunction(), indexNames))));
+  }
+
+  protected static List<String> getIndexNames(final Object expr) {
+    if (expr instanceof DependenceExpression) {
+      return _getIndexNames((DependenceExpression)expr);
+    } else if (expr instanceof StandardEquation) {
+      return _getIndexNames((StandardEquation)expr);
+    } else if (expr instanceof AlphaExpression) {
+      return _getIndexNames((AlphaExpression)expr);
+    } else if (expr != null) {
+      return _getIndexNames(expr);
+    } else {
+      throw new IllegalArgumentException("Unhandled parameter types: " +
+        Arrays.<Object>asList(expr).toString());
+    }
+  }
+}

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.xbase.lib.Conversions;
@@ -50,6 +51,17 @@ import org.eclipse.xtext.xbase.lib.ListExtensions;
  */
 @SuppressWarnings("all")
 public class AlphaUtil {
+  /**
+   * Returns a self-contained copy of the eObject.
+   */
+  public static <T extends EObject> T copyAE(final T eObject) {
+    final EcoreUtil.Copier copier = new EcoreUtil.Copier();
+    final EObject result = copier.copy(eObject);
+    copier.copyReferences();
+    final T t = ((T) result);
+    return t;
+  }
+
   /**
    * Given a name candidate, ensures that it does not conflict
    * with existing variables. If a variable is in conflict,

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
@@ -390,12 +390,19 @@ public class AlphaUtil {
     if (_greaterThan) {
       throw new RuntimeException("Need n or more index names to rename n-d space.");
     }
-    ISLMultiAff res = maff;
-    ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, n, true);
-    for (final Integer i : _doubleDotLessThan) {
-      res = res.setDimName(ISLDimType.isl_dim_in, (i).intValue(), names.get((i).intValue()));
-    }
-    return res;
+    return AlphaUtil.renameFirstIndices(maff, names);
+  }
+
+  /**
+   * Renames as many inputs of the given multi-affine expression as possible.
+   * If more names are given than there are inputs, then all the inputs will be renamed.
+   */
+  public static ISLMultiAff renameFirstIndices(final ISLMultiAff maff, final List<String> names) {
+    final int maxIndex = Integer.min(maff.getNbOutputs(), names.size());
+    final Function2<ISLMultiAff, Integer, ISLMultiAff> _function = (ISLMultiAff _maff, Integer dim) -> {
+      return _maff.setDimName(ISLDimType.isl_dim_in, (dim).intValue(), names.get((dim).intValue()));
+    };
+    return IterableExtensions.<Integer, ISLMultiAff>fold(new ExclusiveRange(0, maxIndex, true), maff, _function);
   }
 
   public static ISLPWQPolynomial renameIndices(final ISLPWQPolynomial pwqp, final List<String> names) {
@@ -458,10 +465,19 @@ public class AlphaUtil {
       InputOutput.println();
       throw new RuntimeException("Need n or more index names to rename n-d space.");
     }
+    return AlphaUtil.renameFirstOutputs(maff, names);
+  }
+
+  /**
+   * Renames as many outputs of the given multi-affine expression as possible.
+   * If more names are given than there are outputs, then all the outputs will be renamed.
+   */
+  public static ISLMultiAff renameFirstOutputs(final ISLMultiAff maff, final List<String> names) {
+    final int maxIndex = Integer.min(maff.getNbOutputs(), names.size());
     final Function2<ISLMultiAff, Integer, ISLMultiAff> _function = (ISLMultiAff _maff, Integer dim) -> {
       return _maff.setDimName(ISLDimType.isl_dim_out, (dim).intValue(), names.get((dim).intValue()));
     };
-    return IterableExtensions.<Integer, ISLMultiAff>fold(new ExclusiveRange(0, nbDims, true), maff, _function);
+    return IterableExtensions.<Integer, ISLMultiAff>fold(new ExclusiveRange(0, maxIndex, true), maff, _function);
   }
 
   /**

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
@@ -403,7 +403,7 @@ public class AlphaUtil {
    * If more names are given than there are inputs, then all the inputs will be renamed.
    */
   public static ISLMultiAff renameFirstIndices(final ISLMultiAff maff, final List<String> names) {
-    final int maxIndex = Integer.min(maff.getNbOutputs(), names.size());
+    final int maxIndex = Integer.min(maff.getNbInputs(), names.size());
     final Function2<ISLMultiAff, Integer, ISLMultiAff> _function = (ISLMultiAff _maff, Integer dim) -> {
       return _maff.setDimName(ISLDimType.isl_dim_in, (dim).intValue(), names.get((dim).intValue()));
     };

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
@@ -390,7 +390,12 @@ public class AlphaUtil {
     if (_greaterThan) {
       throw new RuntimeException("Need n or more index names to rename n-d space.");
     }
-    return AlphaUtil.renameFirstIndices(maff, names);
+    ISLMultiAff res = maff;
+    ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, n, true);
+    for (final Integer i : _doubleDotLessThan) {
+      res = res.setDimName(ISLDimType.isl_dim_in, (i).intValue(), names.get((i).intValue()));
+    }
+    return res;
   }
 
   /**
@@ -465,7 +470,10 @@ public class AlphaUtil {
       InputOutput.println();
       throw new RuntimeException("Need n or more index names to rename n-d space.");
     }
-    return AlphaUtil.renameFirstOutputs(maff, names);
+    final Function2<ISLMultiAff, Integer, ISLMultiAff> _function = (ISLMultiAff _maff, Integer dim) -> {
+      return _maff.setDimName(ISLDimType.isl_dim_out, (dim).intValue(), names.get((dim).intValue()));
+    };
+    return IterableExtensions.<Integer, ISLMultiAff>fold(new ExclusiveRange(0, nbDims, true), maff, _function);
   }
 
   /**

--- a/tests/alpha.model.tests/resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha
@@ -1,0 +1,19 @@
+package alpha.model.tests.transformations.standardizeNames {
+	affine useEquationNames [N]->{:N>5}
+		inputs X1, X2: {[i,j]: 0<=i,j<N}
+		outputs Y: {[k,l]: 0<=k,l<N}
+		let Y[p,q] = case {
+			{[r,s]: r >  3}: (t,u->t,u)@X1;
+			{[a,b]: a <= 3}: (c,d->c,d)@X2;
+		};
+	.
+	
+	affine useVariableNames [N]->{:N>5}
+		inputs X1, X2: {[i,j]: 0<=i,j<N}
+		outputs Y: {[k,l]: 0<=k,l<N}
+		let Y = case {
+			{[r,s]: r >  3}: (t,u->t,u)@X1;
+			{[a,b]: a <= 3}: (c,d->c,d)@X2;
+		};
+	.
+}

--- a/tests/alpha.model.tests/resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha
@@ -28,4 +28,16 @@ package alpha.model.tests.transformations.standardizeNames {
 		outputs Y: {[j]: 0<=j<N}
 		let Y = val(k->7);
 	.
+	
+	affine useEquationNames_03 [N]->{:N>5}
+		inputs X: {[i,j]: 0<=i,j<N}
+		outputs Y: {[k]: 0<=k<N}
+		let Y[p] = reduce(+, [q], X);
+	.
+	
+	affine useVariableNames_03 [N]->{:N>5}
+		inputs X: {[i,j]: 0<=i,j<N}
+		outputs Y: {[j]: 0<=j<N}
+		let Y = reduce(+, (p,q->p), X);
+	.
 }

--- a/tests/alpha.model.tests/resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha
@@ -1,5 +1,5 @@
 package alpha.model.tests.transformations.standardizeNames {
-	affine useEquationNames [N]->{:N>5}
+	affine useEquationNames_01 [N]->{:N>5}
 		inputs X1, X2: {[i,j]: 0<=i,j<N}
 		outputs Y: {[k,l]: 0<=k,l<N}
 		let Y[p,q] = case {
@@ -8,12 +8,24 @@ package alpha.model.tests.transformations.standardizeNames {
 		};
 	.
 	
-	affine useVariableNames [N]->{:N>5}
+	affine useVariableNames_01 [N]->{:N>5}
 		inputs X1, X2: {[i,j]: 0<=i,j<N}
 		outputs Y: {[k,l]: 0<=k,l<N}
 		let Y = case {
 			{[r,s]: r >  3}: (t,u->t,u)@X1;
 			{[a,b]: a <= 3}: (c,d->c,d)@X2;
 		};
+	.
+	
+	affine useEquationNames_02 [N]->{:N>5}
+		inputs X: {[i]: 0<=i<N}
+		outputs Y: {[j]: 0<=j<N}
+		let Y[k] = val[7];
+	.
+	
+	affine useVariableNames_02 [N]->{:N>5}
+		inputs X: {[i]: 0<=i<N}
+		outputs Y: {[j]: 0<=j<N}
+		let Y = val(k->7);
 	.
 }

--- a/tests/alpha.model.tests/src/alpha/model/tests/transformations/StandardizeNamesTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/transformations/StandardizeNamesTest.xtend
@@ -12,6 +12,7 @@ import org.junit.Test
 import static org.junit.Assert.*
 
 import static extension alpha.commands.UtilityBase.*
+import alpha.model.IndexExpression
 
 class StandardizeNamesTest {
 	/** The path to the Alpha file for these unit tests. */
@@ -22,17 +23,33 @@ class StandardizeNamesTest {
 	///////////////////////////////////////////////////
 	
 	@Test
-	def useEquationNames() {
-		val equation = getEquation("useEquationNames", "Y")
+	def useEquationNames_01() {
+		val equation = getEquation("useEquationNames_01", "Y")
 		val expectedNames = equation.indexNames
-		assertNamesCorrect(expectedNames, equation)
+		assertNamesCorrect_caseRestrictDep(expectedNames, equation)
 	}
 	
 	@Test
-	def useVariableNames() {
-		val equation = getEquation("useVariableNames", "Y")
+	def useVariableNames_01() {
+		val equation = getEquation("useVariableNames_01", "Y")
 		val expectedNames = equation.variable.domain.indexNames
-		assertNamesCorrect(expectedNames, equation)
+		assertNamesCorrect_caseRestrictDep(expectedNames, equation)
+	}
+	
+	@Test
+	def void useEquationNames_02() {
+		val equation = getEquation("useEquationNames_02", "Y")
+		val expectedNames = equation.indexNames
+		StandardizeNames.apply(equation)
+		assertIndexExprNamesCorrect(expectedNames, equation.expr as IndexExpression)
+	}
+	
+	@Test
+	def void useVariableNames_02() {
+		val equation = getEquation("useVariableNames_02", "Y")
+		val expectedNames = equation.variable.domain.indexNames
+		StandardizeNames.apply(equation)
+		assertIndexExprNamesCorrect(expectedNames, equation.expr as IndexExpression)
 	}
 	
 	///////////////////////////////////////////////////
@@ -56,7 +73,7 @@ class StandardizeNamesTest {
 	 *     D2: R2@E2;
 	 * }
 	 */
-	def static assertNamesCorrect(List<String> expectedNames, StandardEquation equation) {
+	def static assertNamesCorrect_caseRestrictDep(List<String> expectedNames, StandardEquation equation) {
 		StandardizeNames.apply(equation)
 		
 		// Capture what the AST became.
@@ -97,5 +114,11 @@ class StandardizeNamesTest {
 			assertNotNull(name)
 			assertNotEquals("", name)
 		}
+	}
+	
+	def static assertIndexExprNamesCorrect(List<String> expectedNames, IndexExpression expr) {
+		assertTrue(expectedNames.elementsEqual(expr.contextDomain.indexNames))
+		assertTrue(expectedNames.elementsEqual(expr.expressionDomain.indexNames))
+		assertTrue(expectedNames.elementsEqual(expr.function.space.inputNames))
 	}
 }

--- a/tests/alpha.model.tests/src/alpha/model/tests/transformations/StandardizeNamesTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/transformations/StandardizeNamesTest.xtend
@@ -1,0 +1,101 @@
+package alpha.model.tests.transformations
+
+import alpha.model.AlphaModelLoader
+import alpha.model.CaseExpression
+import alpha.model.DependenceExpression
+import alpha.model.RestrictExpression
+import alpha.model.StandardEquation
+import alpha.model.transformation.StandardizeNames
+import java.util.List
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+import static extension alpha.commands.UtilityBase.*
+
+class StandardizeNamesTest {
+	/** The path to the Alpha file for these unit tests. */
+	static val alphaFile = "resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha";
+	
+	///////////////////////////////////////////////////
+	// Unit Tests
+	///////////////////////////////////////////////////
+	
+	@Test
+	def useEquationNames() {
+		val equation = getEquation("useEquationNames", "Y")
+		val expectedNames = equation.indexNames
+		assertNamesCorrect(expectedNames, equation)
+	}
+	
+	@Test
+	def useVariableNames() {
+		val equation = getEquation("useVariableNames", "Y")
+		val expectedNames = equation.variable.domain.indexNames
+		assertNamesCorrect(expectedNames, equation)
+	}
+	
+	///////////////////////////////////////////////////
+	// Helper Functions
+	///////////////////////////////////////////////////
+	
+	/** Gets the desired system for these unit tests. */
+	static def getEquation(String system, String equation) {
+		return AlphaModelLoader.loadModel(alphaFile)
+			.GetSystem(system)
+			.GetSystemBody(0)
+			.GetEquation(equation)
+	}
+	
+	/**
+	 * Asserts that the names are correct.
+	 * The equation's expression is expected to be of the following form:
+	 * 
+	 * case {
+	 *     D1: R1@E1;
+	 *     D2: R2@E2;
+	 * }
+	 */
+	def static assertNamesCorrect(List<String> expectedNames, StandardEquation equation) {
+		StandardizeNames.apply(equation)
+		
+		// Capture what the AST became.
+		// We expect a case statement with two cases.
+		// Each case is of the form "restrict: dependence@variable".
+		val caseExpr = equation.expr as CaseExpression
+
+		val restrict1 = caseExpr.exprs.get(0) as RestrictExpression
+		assertRestrictNamesCorrect(expectedNames, restrict1)
+		
+		val dependence1 = restrict1.expr as DependenceExpression
+		assertDependenceNamesCorrect(expectedNames, dependence1)
+		
+		val restrict2 = caseExpr.exprs.get(1) as RestrictExpression
+		assertRestrictNamesCorrect(expectedNames, restrict2)
+		
+		val dependence2 = restrict2.expr as DependenceExpression
+		assertDependenceNamesCorrect(expectedNames, dependence2)
+	}
+	
+	/** Checks that the names of a restrict expression were updated correctly. */
+	def static assertRestrictNamesCorrect(List<String> expectedNames, RestrictExpression expr) {
+		assertTrue(expectedNames.elementsEqual(expr.contextDomain.indexNames))
+		assertTrue(expectedNames.elementsEqual(expr.expressionDomain.indexNames))
+		assertTrue(expectedNames.elementsEqual(expr.restrictDomain.indexNames))
+	}
+	
+	/** Checks that the names of a dependence expression were updated correctly. */
+	def static assertDependenceNamesCorrect(List<String> expectedNames, DependenceExpression expr) {
+		assertTrue(expectedNames.elementsEqual(expr.contextDomain.indexNames))
+		assertTrue(expectedNames.elementsEqual(expr.expressionDomain.indexNames))
+		assertTrue(expectedNames.elementsEqual(expr.function.space.inputNames))
+		
+		// We don't care what the output names are, just that they exist (i.e., not null or empty).
+		val outputNames = expr.function.space.outputNames
+		assertEquals(outputNames.length, expr.function.nbOutputs)
+		for (name : outputNames) {
+			assertNotNull(name)
+			assertNotEquals("", name)
+		}
+	}
+}

--- a/tests/alpha.model.tests/src/alpha/model/tests/transformations/StandardizeNamesTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/transformations/StandardizeNamesTest.xtend
@@ -13,6 +13,7 @@ import static org.junit.Assert.*
 
 import static extension alpha.commands.UtilityBase.*
 import alpha.model.IndexExpression
+import alpha.model.ReduceExpression
 
 class StandardizeNamesTest {
 	/** The path to the Alpha file for these unit tests. */
@@ -50,6 +51,22 @@ class StandardizeNamesTest {
 		val expectedNames = equation.variable.domain.indexNames
 		StandardizeNames.apply(equation)
 		assertIndexExprNamesCorrect(expectedNames, equation.expr as IndexExpression)
+	}
+	
+	@Test
+	def void useEquationNames_03() {
+		val equation = getEquation("useEquationNames_03", "Y")
+		val expectedNames = equation.indexNames
+		StandardizeNames.apply(equation)
+		assertReduceNamesCorrect(expectedNames, equation.expr as ReduceExpression)
+	}
+	
+	@Test
+	def void useVariableNames_03() {
+		val equation = getEquation("useVariableNames_03", "Y")
+		val expectedNames = equation.variable.domain.indexNames
+		StandardizeNames.apply(equation)
+		assertReduceNamesCorrect(expectedNames, equation.expr as ReduceExpression)
 	}
 	
 	///////////////////////////////////////////////////
@@ -120,5 +137,21 @@ class StandardizeNamesTest {
 		assertTrue(expectedNames.elementsEqual(expr.contextDomain.indexNames))
 		assertTrue(expectedNames.elementsEqual(expr.expressionDomain.indexNames))
 		assertTrue(expectedNames.elementsEqual(expr.function.space.inputNames))
+	}
+	
+	def static assertReduceNamesCorrect(List<String> expectedNames, ReduceExpression expr) {
+		// The context and expression domains for the reduction should match the expected names.
+		assertTrue(expectedNames.elementsEqual(expr.contextDomain.indexNames))
+		assertTrue(expectedNames.elementsEqual(expr.expressionDomain.indexNames))
+		
+		// The projection function's inputs should start with the expected names.
+		val projectionNamesStart = expr.projection.space.inputNames.take(expectedNames.size)
+		assertTrue(expectedNames.elementsEqual(projectionNamesStart))
+		
+		// The names of the context and expression domains for the reduction body
+		// should match the names of the inputs to the projection function.
+		val expectedBodyNames = expr.projection.space.inputNames
+		assertTrue(expectedBodyNames.elementsEqual(expr.body.contextDomain.indexNames))
+		assertTrue(expectedBodyNames.elementsEqual(expr.body.expressionDomain.indexNames))
 	}
 }

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/StandardizeNamesTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/StandardizeNamesTest.java
@@ -6,6 +6,7 @@ import alpha.model.AlphaModelLoader;
 import alpha.model.CaseExpression;
 import alpha.model.DependenceExpression;
 import alpha.model.IndexExpression;
+import alpha.model.ReduceExpression;
 import alpha.model.RestrictExpression;
 import alpha.model.StandardEquation;
 import alpha.model.transformation.StandardizeNames;
@@ -54,6 +55,24 @@ public class StandardizeNamesTest {
     StandardizeNames.apply(equation);
     AlphaExpression _expr = equation.getExpr();
     StandardizeNamesTest.assertIndexExprNamesCorrect(expectedNames, ((IndexExpression) _expr));
+  }
+
+  @Test
+  public void useEquationNames_03() {
+    final StandardEquation equation = StandardizeNamesTest.getEquation("useEquationNames_03", "Y");
+    final EList<String> expectedNames = equation.getIndexNames();
+    StandardizeNames.apply(equation);
+    AlphaExpression _expr = equation.getExpr();
+    StandardizeNamesTest.assertReduceNamesCorrect(expectedNames, ((ReduceExpression) _expr));
+  }
+
+  @Test
+  public void useVariableNames_03() {
+    final StandardEquation equation = StandardizeNamesTest.getEquation("useVariableNames_03", "Y");
+    final List<String> expectedNames = equation.getVariable().getDomain().getIndexNames();
+    StandardizeNames.apply(equation);
+    AlphaExpression _expr = equation.getExpr();
+    StandardizeNamesTest.assertReduceNamesCorrect(expectedNames, ((ReduceExpression) _expr));
   }
 
   /**
@@ -124,5 +143,15 @@ public class StandardizeNamesTest {
     Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getContextDomain().getIndexNames()));
     Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getExpressionDomain().getIndexNames()));
     Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getFunction().getSpace().getInputNames()));
+  }
+
+  public static void assertReduceNamesCorrect(final List<String> expectedNames, final ReduceExpression expr) {
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getContextDomain().getIndexNames()));
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getExpressionDomain().getIndexNames()));
+    final Iterable<String> projectionNamesStart = IterableExtensions.<String>take(expr.getProjection().getSpace().getInputNames(), expectedNames.size());
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, projectionNamesStart));
+    final List<String> expectedBodyNames = expr.getProjection().getSpace().getInputNames();
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedBodyNames, expr.getBody().getContextDomain().getIndexNames()));
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedBodyNames, expr.getBody().getExpressionDomain().getIndexNames()));
   }
 }

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/StandardizeNamesTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/StandardizeNamesTest.java
@@ -1,0 +1,103 @@
+package alpha.model.tests.transformations;
+
+import alpha.commands.UtilityBase;
+import alpha.model.AlphaExpression;
+import alpha.model.AlphaModelLoader;
+import alpha.model.CaseExpression;
+import alpha.model.DependenceExpression;
+import alpha.model.RestrictExpression;
+import alpha.model.StandardEquation;
+import alpha.model.transformation.StandardizeNames;
+import java.util.List;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class StandardizeNamesTest {
+  /**
+   * The path to the Alpha file for these unit tests.
+   */
+  private static final String alphaFile = "resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha";
+
+  @Test
+  public void useEquationNames() {
+    final StandardEquation equation = StandardizeNamesTest.getEquation("useEquationNames", "Y");
+    final EList<String> expectedNames = equation.getIndexNames();
+    StandardizeNamesTest.assertNamesCorrect(expectedNames, equation);
+  }
+
+  @Test
+  public void useVariableNames() {
+    final StandardEquation equation = StandardizeNamesTest.getEquation("useVariableNames", "Y");
+    final List<String> expectedNames = equation.getVariable().getDomain().getIndexNames();
+    StandardizeNamesTest.assertNamesCorrect(expectedNames, equation);
+  }
+
+  /**
+   * Gets the desired system for these unit tests.
+   */
+  public static StandardEquation getEquation(final String system, final String equation) {
+    try {
+      return UtilityBase.GetEquation(UtilityBase.GetSystemBody(UtilityBase.GetSystem(AlphaModelLoader.loadModel(StandardizeNamesTest.alphaFile), system), 0), equation);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+
+  /**
+   * Asserts that the names are correct.
+   * The equation's expression is expected to be of the following form:
+   * 
+   * case {
+   *     D1: R1@E1;
+   *     D2: R2@E2;
+   * }
+   */
+  public static void assertNamesCorrect(final List<String> expectedNames, final StandardEquation equation) {
+    StandardizeNames.apply(equation);
+    AlphaExpression _expr = equation.getExpr();
+    final CaseExpression caseExpr = ((CaseExpression) _expr);
+    AlphaExpression _get = caseExpr.getExprs().get(0);
+    final RestrictExpression restrict1 = ((RestrictExpression) _get);
+    StandardizeNamesTest.assertRestrictNamesCorrect(expectedNames, restrict1);
+    AlphaExpression _expr_1 = restrict1.getExpr();
+    final DependenceExpression dependence1 = ((DependenceExpression) _expr_1);
+    StandardizeNamesTest.assertDependenceNamesCorrect(expectedNames, dependence1);
+    AlphaExpression _get_1 = caseExpr.getExprs().get(1);
+    final RestrictExpression restrict2 = ((RestrictExpression) _get_1);
+    StandardizeNamesTest.assertRestrictNamesCorrect(expectedNames, restrict2);
+    AlphaExpression _expr_2 = restrict2.getExpr();
+    final DependenceExpression dependence2 = ((DependenceExpression) _expr_2);
+    StandardizeNamesTest.assertDependenceNamesCorrect(expectedNames, dependence2);
+  }
+
+  /**
+   * Checks that the names of a restrict expression were updated correctly.
+   */
+  public static void assertRestrictNamesCorrect(final List<String> expectedNames, final RestrictExpression expr) {
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getContextDomain().getIndexNames()));
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getExpressionDomain().getIndexNames()));
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getRestrictDomain().getIndexNames()));
+  }
+
+  /**
+   * Checks that the names of a dependence expression were updated correctly.
+   */
+  public static void assertDependenceNamesCorrect(final List<String> expectedNames, final DependenceExpression expr) {
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getContextDomain().getIndexNames()));
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getExpressionDomain().getIndexNames()));
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getFunction().getSpace().getInputNames()));
+    final List<String> outputNames = expr.getFunction().getSpace().getOutputNames();
+    Assert.assertEquals(((Object[])Conversions.unwrapArray(outputNames, Object.class)).length, expr.getFunction().getNbOutputs());
+    for (final String name : outputNames) {
+      {
+        Assert.assertNotNull(name);
+        Assert.assertNotEquals("", name);
+      }
+    }
+  }
+}

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/StandardizeNamesTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformations/StandardizeNamesTest.java
@@ -5,6 +5,7 @@ import alpha.model.AlphaExpression;
 import alpha.model.AlphaModelLoader;
 import alpha.model.CaseExpression;
 import alpha.model.DependenceExpression;
+import alpha.model.IndexExpression;
 import alpha.model.RestrictExpression;
 import alpha.model.StandardEquation;
 import alpha.model.transformation.StandardizeNames;
@@ -24,17 +25,35 @@ public class StandardizeNamesTest {
   private static final String alphaFile = "resources/src-valid/transformation-tests/standardize-names/standardizeNames.alpha";
 
   @Test
-  public void useEquationNames() {
-    final StandardEquation equation = StandardizeNamesTest.getEquation("useEquationNames", "Y");
+  public void useEquationNames_01() {
+    final StandardEquation equation = StandardizeNamesTest.getEquation("useEquationNames_01", "Y");
     final EList<String> expectedNames = equation.getIndexNames();
-    StandardizeNamesTest.assertNamesCorrect(expectedNames, equation);
+    StandardizeNamesTest.assertNamesCorrect_caseRestrictDep(expectedNames, equation);
   }
 
   @Test
-  public void useVariableNames() {
-    final StandardEquation equation = StandardizeNamesTest.getEquation("useVariableNames", "Y");
+  public void useVariableNames_01() {
+    final StandardEquation equation = StandardizeNamesTest.getEquation("useVariableNames_01", "Y");
     final List<String> expectedNames = equation.getVariable().getDomain().getIndexNames();
-    StandardizeNamesTest.assertNamesCorrect(expectedNames, equation);
+    StandardizeNamesTest.assertNamesCorrect_caseRestrictDep(expectedNames, equation);
+  }
+
+  @Test
+  public void useEquationNames_02() {
+    final StandardEquation equation = StandardizeNamesTest.getEquation("useEquationNames_02", "Y");
+    final EList<String> expectedNames = equation.getIndexNames();
+    StandardizeNames.apply(equation);
+    AlphaExpression _expr = equation.getExpr();
+    StandardizeNamesTest.assertIndexExprNamesCorrect(expectedNames, ((IndexExpression) _expr));
+  }
+
+  @Test
+  public void useVariableNames_02() {
+    final StandardEquation equation = StandardizeNamesTest.getEquation("useVariableNames_02", "Y");
+    final List<String> expectedNames = equation.getVariable().getDomain().getIndexNames();
+    StandardizeNames.apply(equation);
+    AlphaExpression _expr = equation.getExpr();
+    StandardizeNamesTest.assertIndexExprNamesCorrect(expectedNames, ((IndexExpression) _expr));
   }
 
   /**
@@ -57,7 +76,7 @@ public class StandardizeNamesTest {
    *     D2: R2@E2;
    * }
    */
-  public static void assertNamesCorrect(final List<String> expectedNames, final StandardEquation equation) {
+  public static void assertNamesCorrect_caseRestrictDep(final List<String> expectedNames, final StandardEquation equation) {
     StandardizeNames.apply(equation);
     AlphaExpression _expr = equation.getExpr();
     final CaseExpression caseExpr = ((CaseExpression) _expr);
@@ -99,5 +118,11 @@ public class StandardizeNamesTest {
         Assert.assertNotEquals("", name);
       }
     }
+  }
+
+  public static void assertIndexExprNamesCorrect(final List<String> expectedNames, final IndexExpression expr) {
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getContextDomain().getIndexNames()));
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getExpressionDomain().getIndexNames()));
+    Assert.assertTrue(IterableExtensions.elementsEqual(expectedNames, expr.getFunction().getSpace().getInputNames()));
   }
 }


### PR DESCRIPTION
Add a transformation to standardize names throughout an Alpha system. This is done top-down, that way a parent's names are set before visiting its children.

This PR also adds a function which performs a deep copy on an AST (or part of an AST), as both Louis and I will need it soon.

When updating the names within an expression, the names to use are determined as follows:
1. If the expression's parent is a standard equation:
    1. Names on the left-hand side of the equation.
    2. The names used when declaring the variable.
    3. Default names are selected.
2. If the parent is a dependence expression:
    1. The names from the parent dependence function's output dimensions are used.
3. If the parent is a reduce expression:
    1. The names from the parent reduction's projection function's output dimensions are used.
4. Otherwise:
    1. The names come from the parent's context domain.

Once names are selected, the following updates are performed:
1. The context domain's indices are set to the selected names.
3. The expression domain's indices are set to the selected names.
5. If the expression is a restrict expression:
    1. The restrict domain's indices are set to the selected names.
6. If the expression is a dependence expression:
    1. The dependence function's inputs are set to the selected names.
    3. The dependence function's outputs are set to some default names.