### PR TITLE
Move complexity calculation to a separate class

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         org.junit.runner.JUnitCore alpha.model.tests.AlphaCheckProgramTest
         org.junit.runner.JUnitCore alpha.model.tests.AlphaNormalizeTest
         org.junit.runner.JUnitCore alpha.model.tests.AlphaShowTest
+        org.junit.runner.JUnitCore alpha.model.tests.ComplexityCalculatorTest
         org.junit.runner.JUnitCore alpha.model.tests.transformation.reduction.NormalizeReductionDeepTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.DistributivityTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.FactorOutFromReductionTest

--- a/bundles/alpha.model/src/alpha/model/ComplexityCalculator.xtend
+++ b/bundles/alpha.model/src/alpha/model/ComplexityCalculator.xtend
@@ -1,0 +1,33 @@
+package alpha.model
+
+import alpha.model.util.AbstractAlphaCompleteVisitor
+
+import static extension alpha.model.util.ISLUtil.dimensionality
+
+class ComplexityCalculator extends AbstractAlphaCompleteVisitor {
+
+	int maxComplexity
+
+	def static int complexity(AlphaVisitable av) {
+		val visitor = new ComplexityCalculator
+		visitor.accept(av)
+		return visitor.maxComplexity
+	}
+	
+	def updateComplexity(int c) {
+		if (c > maxComplexity)
+			maxComplexity = c
+	}
+	
+	override outStandardEquation(StandardEquation eq) {
+		updateComplexity(eq.variable.domain.dimensionality)
+	}
+	
+	override outUseEquation(UseEquation eq) {
+		throw new Exception('Complexity calculation of UseEquations not yet implemented')
+	}
+	
+	override outReduceExpression(ReduceExpression re) {
+		updateComplexity(re.body.contextDomain.dimensionality)
+	}
+}

--- a/bundles/alpha.model/src/alpha/model/ComplexityCalculator.xtend
+++ b/bundles/alpha.model/src/alpha/model/ComplexityCalculator.xtend
@@ -1,14 +1,34 @@
 package alpha.model
 
 import alpha.model.util.AbstractAlphaCompleteVisitor
+import fr.irisa.cairn.jnimap.isl.ISLDimType
 
+import static extension alpha.model.util.AlphaUtil.getContainerSystem
 import static extension alpha.model.util.ISLUtil.dimensionality
+
+/**
+ * This class reports the overall complexity of the given node in the AST.
+ * It simply visits every node in the tree and computes the dimensionality
+ * (i.e., number of free dimensions) of its context domain. Then it reports
+ * the max dimensionality encountered.
+ * 
+ * This is primarily intended to be used by the simplifying reductions 
+ * implementation where we simply need to visit all standard equations and 
+ * reduce expression. It currently only handles programs with a single parameter
+ * and throws an exception otherwise. 
+ * 
+ */
 
 class ComplexityCalculator extends AbstractAlphaCompleteVisitor {
 
 	int maxComplexity
 
 	def static int complexity(AlphaVisitable av) {
+		
+		val system = av.getContainerSystem
+		if (system !== null && system.parameterDomain.dim(ISLDimType.isl_dim_param) > 1)
+			throw new UnsupportedOperationException("Current complexity calculator only works for systems containing a single parameter.")
+		
 		val visitor = new ComplexityCalculator
 		visitor.accept(av)
 		return visitor.maxComplexity
@@ -24,7 +44,7 @@ class ComplexityCalculator extends AbstractAlphaCompleteVisitor {
 	}
 	
 	override outUseEquation(UseEquation eq) {
-		throw new Exception('Complexity calculation of UseEquations not yet implemented')
+		throw new UnsupportedOperationException('Complexity calculation of UseEquations not yet implemented')
 	}
 	
 	override outReduceExpression(ReduceExpression re) {

--- a/bundles/alpha.model/src/alpha/model/transformation/automation/OptimalSimplifyingReductions.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/automation/OptimalSimplifyingReductions.xtend
@@ -34,6 +34,7 @@ import java.util.Map
 import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.ecore.util.EcoreUtil
 
+import static extension alpha.model.ComplexityCalculator.complexity
 import static extension alpha.model.util.AlphaUtil.getContainerEquation
 import static extension alpha.model.util.AlphaUtil.getContainerRoot
 import static extension alpha.model.util.AlphaUtil.getContainerSystemBody
@@ -230,18 +231,6 @@ class OptimalSimplifyingReductions {
 	}
 	private def dispatch void optimizeEquation(StandardEquation eq, AlphaExpression ae, State state) {
 		eq.explored = true
-	}
-	
-	def static int complexity(SystemBody body) {
-		body.equations
-			.filter[eq | eq instanceof StandardEquation]
-			.map[eq | eq as StandardEquation].map[eq |
-				if (eq.expr instanceof ReduceExpression) {
-					(eq.expr as ReduceExpression).body.contextDomain.dimensionality
-				} else {
-					eq.variable.domain.dimensionality
-				}
-			].max
 	}
 	
 	/**

--- a/bundles/alpha.model/xtend-gen/alpha/model/ComplexityCalculator.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/ComplexityCalculator.java
@@ -1,0 +1,43 @@
+package alpha.model;
+
+import alpha.model.util.AbstractAlphaCompleteVisitor;
+import alpha.model.util.ISLUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+
+@SuppressWarnings("all")
+public class ComplexityCalculator extends AbstractAlphaCompleteVisitor {
+  private int maxComplexity;
+
+  public static int complexity(final AlphaVisitable av) {
+    final ComplexityCalculator visitor = new ComplexityCalculator();
+    visitor.accept(av);
+    return visitor.maxComplexity;
+  }
+
+  public int updateComplexity(final int c) {
+    int _xifexpression = (int) 0;
+    if ((c > this.maxComplexity)) {
+      _xifexpression = this.maxComplexity = c;
+    }
+    return _xifexpression;
+  }
+
+  @Override
+  public void outStandardEquation(final StandardEquation eq) {
+    this.updateComplexity(ISLUtil.dimensionality(eq.getVariable().getDomain()));
+  }
+
+  @Override
+  public void outUseEquation(final UseEquation eq) {
+    try {
+      throw new Exception("Complexity calculation of UseEquations not yet implemented");
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+
+  @Override
+  public void outReduceExpression(final ReduceExpression re) {
+    this.updateComplexity(ISLUtil.dimensionality(re.getBody().getContextDomain()));
+  }
+}

--- a/bundles/alpha.model/xtend-gen/alpha/model/ComplexityCalculator.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/ComplexityCalculator.java
@@ -1,14 +1,30 @@
 package alpha.model;
 
 import alpha.model.util.AbstractAlphaCompleteVisitor;
+import alpha.model.util.AlphaUtil;
 import alpha.model.util.ISLUtil;
-import org.eclipse.xtext.xbase.lib.Exceptions;
+import fr.irisa.cairn.jnimap.isl.ISLDimType;
 
+/**
+ * This class reports the overall complexity of the given node in the AST.
+ * It simply visits every node in the tree and computes the dimensionality
+ * (i.e., number of free dimensions) of its context domain. Then it reports
+ * the max dimensionality encountered.
+ * 
+ * This is primarily intended to be used by the simplifying reductions
+ * implementation where we simply need to visit all standard equations and
+ * reduce expression. It currently only handles programs with a single parameter
+ * and throws an exception otherwise.
+ */
 @SuppressWarnings("all")
 public class ComplexityCalculator extends AbstractAlphaCompleteVisitor {
   private int maxComplexity;
 
   public static int complexity(final AlphaVisitable av) {
+    final AlphaSystem system = AlphaUtil.getContainerSystem(av);
+    if (((system != null) && (system.getParameterDomain().dim(ISLDimType.isl_dim_param) > 1))) {
+      throw new UnsupportedOperationException("Current complexity calculator only works for systems containing a single parameter.");
+    }
     final ComplexityCalculator visitor = new ComplexityCalculator();
     visitor.accept(av);
     return visitor.maxComplexity;
@@ -29,11 +45,7 @@ public class ComplexityCalculator extends AbstractAlphaCompleteVisitor {
 
   @Override
   public void outUseEquation(final UseEquation eq) {
-    try {
-      throw new Exception("Complexity calculation of UseEquations not yet implemented");
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+    throw new UnsupportedOperationException("Complexity calculation of UseEquations not yet implemented");
   }
 
   @Override

--- a/tests/alpha.model.tests/META-INF/MANIFEST.MF
+++ b/tests/alpha.model.tests/META-INF/MANIFEST.MF
@@ -17,4 +17,5 @@ Require-Bundle: alpha.model,
  alpha.commands.groovy,
  alpha.commands,
  fr.irisa.cairn.jnimap.barvinok;resolution:=optional,
- fr.irisa.cairn.jnimap.polylib;resolution:=optional
+ fr.irisa.cairn.jnimap.polylib;resolution:=optional,
+ alpha.targetmapping.xtext;bundle-version="0.1.0"

--- a/tests/alpha.model.tests/src/alpha/model/tests/ComplexityCalculatorTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/ComplexityCalculatorTest.xtend
@@ -11,7 +11,7 @@ import static extension alpha.model.ComplexityCalculator.complexity
 class ComplexityCalculatorTest {
 	
 	@Test
-	def testComplexity_01() {
+	def void testComplexity_01() {
 		val root = loadValidFile('transformation-tests/simplify-expressions/scalarReduction1.alpha') 
 		val system = GetSystem(root, 'scalarReduction1a')
 		
@@ -19,7 +19,7 @@ class ComplexityCalculatorTest {
 	}
 	
 	@Test
-	def testComplexity_02() {
+	def void testComplexity_02() {
 		val root = loadValidFile('transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha') 
 		
 		assertEquals(GetSystem(root, 'topLevelReduction').complexity, 2)
@@ -29,17 +29,12 @@ class ComplexityCalculatorTest {
 	}
 	
 	@Test
-	def testComplexity_03() {
-		val root = loadValidFile('transformation-tests/substitute-by-def/autoRestrict1.alpha') 
+	def void testComplexity_03() {
+		val root = loadValidFile('transformation-tests/substitute-by-def/autoRestrict1.alpha')
 		val system = GetSystem(root, 'autoRestrict1a')
-		
+
 		// this program has multiple parameters and should fail
-		try {
-			system.complexity
-		} catch (UnsupportedOperationException e) {
-			assertTrue(true)
-			return
-		}
-		assertTrue(false)
+		assertThrows(typeof(UnsupportedOperationException), [|system.complexity])
+		
 	}
 }

--- a/tests/alpha.model.tests/src/alpha/model/tests/ComplexityCalculatorTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/ComplexityCalculatorTest.xtend
@@ -1,0 +1,30 @@
+package alpha.model.tests
+
+import org.junit.Test
+
+import static alpha.commands.UtilityBase.GetSystem
+import static alpha.model.tests.util.AlphaTestUtil.loadValidFile
+import static org.junit.Assert.*
+
+import static extension alpha.model.ComplexityCalculator.complexity
+
+class ComplexityCalculatorTest {
+	
+	@Test
+	def testComplexity_01() {
+		val root = loadValidFile('transformation-tests/simplify-expressions/scalarReduction1.alpha') 
+		val system = GetSystem(root, 'scalarReduction1a')
+		
+		assertEquals(system.complexity, 1)
+	}
+	
+	@Test
+	def testComplexity_02() {
+		val root = loadValidFile('transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha') 
+		
+		assertEquals(GetSystem(root, 'topLevelReduction').complexity, 2)
+		assertEquals(GetSystem(root, 'nestedReduction_01').complexity, 3)
+		assertEquals(GetSystem(root, 'nestedReduction_02').complexity, 4)
+		assertEquals(GetSystem(root, 'nestedReduction_03').complexity, 4)
+	}
+}

--- a/tests/alpha.model.tests/src/alpha/model/tests/ComplexityCalculatorTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/ComplexityCalculatorTest.xtend
@@ -27,4 +27,19 @@ class ComplexityCalculatorTest {
 		assertEquals(GetSystem(root, 'nestedReduction_02').complexity, 4)
 		assertEquals(GetSystem(root, 'nestedReduction_03').complexity, 4)
 	}
+	
+	@Test
+	def testComplexity_03() {
+		val root = loadValidFile('transformation-tests/substitute-by-def/autoRestrict1.alpha') 
+		val system = GetSystem(root, 'autoRestrict1a')
+		
+		// this program has multiple parameters and should fail
+		try {
+			system.complexity
+		} catch (UnsupportedOperationException e) {
+			assertTrue(true)
+			return
+		}
+		assertTrue(false)
+	}
 }

--- a/tests/alpha.model.tests/src/alpha/model/tests/util/AlphaTestUtil.java
+++ b/tests/alpha.model.tests/src/alpha/model/tests/util/AlphaTestUtil.java
@@ -3,6 +3,7 @@ package alpha.model.tests.util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -148,5 +149,14 @@ public class AlphaTestUtil {
 				.map(Path::getParent)
 				.filter(Objects::nonNull)
 				.distinct();
+	}
+	
+	/** 
+	 * Load specific file, at path "SRC_VALID/<relativePath>"
+	 * 
+	 * @return AlphaRoot
+	 */
+	public static AlphaRoot loadValidFile(String relativePath) {
+		return alpha.commands.Core.ReadAlpha(SRC_VALID.toString() + "/" + relativePath);
 	}
 }

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/ComplexityCalculatorTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/ComplexityCalculatorTest.java
@@ -1,0 +1,28 @@
+package alpha.model.tests;
+
+import alpha.commands.UtilityBase;
+import alpha.model.AlphaRoot;
+import alpha.model.AlphaSystem;
+import alpha.model.ComplexityCalculator;
+import alpha.model.tests.util.AlphaTestUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class ComplexityCalculatorTest {
+  @Test
+  public void testComplexity_01() {
+    final AlphaRoot root = AlphaTestUtil.loadValidFile("transformation-tests/simplify-expressions/scalarReduction1.alpha");
+    final AlphaSystem system = UtilityBase.GetSystem(root, "scalarReduction1a");
+    Assert.assertEquals(ComplexityCalculator.complexity(system), 1);
+  }
+
+  @Test
+  public void testComplexity_02() {
+    final AlphaRoot root = AlphaTestUtil.loadValidFile("transformation-reduction-tests/normalize-reduction-deep/normalizeReductionDeep.alpha");
+    Assert.assertEquals(ComplexityCalculator.complexity(UtilityBase.GetSystem(root, "topLevelReduction")), 2);
+    Assert.assertEquals(ComplexityCalculator.complexity(UtilityBase.GetSystem(root, "nestedReduction_01")), 3);
+    Assert.assertEquals(ComplexityCalculator.complexity(UtilityBase.GetSystem(root, "nestedReduction_02")), 4);
+    Assert.assertEquals(ComplexityCalculator.complexity(UtilityBase.GetSystem(root, "nestedReduction_03")), 4);
+  }
+}

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/ComplexityCalculatorTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/ComplexityCalculatorTest.java
@@ -5,9 +5,9 @@ import alpha.model.AlphaRoot;
 import alpha.model.AlphaSystem;
 import alpha.model.ComplexityCalculator;
 import alpha.model.tests.util.AlphaTestUtil;
-import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 @SuppressWarnings("all")
 public class ComplexityCalculatorTest {
@@ -31,16 +31,9 @@ public class ComplexityCalculatorTest {
   public void testComplexity_03() {
     final AlphaRoot root = AlphaTestUtil.loadValidFile("transformation-tests/substitute-by-def/autoRestrict1.alpha");
     final AlphaSystem system = UtilityBase.GetSystem(root, "autoRestrict1a");
-    try {
+    final ThrowingRunnable _function = () -> {
       ComplexityCalculator.complexity(system);
-    } catch (final Throwable _t) {
-      if (_t instanceof UnsupportedOperationException) {
-        Assert.assertTrue(true);
-        return;
-      } else {
-        throw Exceptions.sneakyThrow(_t);
-      }
-    }
-    Assert.assertTrue(false);
+    };
+    Assert.<UnsupportedOperationException>assertThrows(UnsupportedOperationException.class, _function);
   }
 }

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/ComplexityCalculatorTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/ComplexityCalculatorTest.java
@@ -5,6 +5,7 @@ import alpha.model.AlphaRoot;
 import alpha.model.AlphaSystem;
 import alpha.model.ComplexityCalculator;
 import alpha.model.tests.util.AlphaTestUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,5 +25,22 @@ public class ComplexityCalculatorTest {
     Assert.assertEquals(ComplexityCalculator.complexity(UtilityBase.GetSystem(root, "nestedReduction_01")), 3);
     Assert.assertEquals(ComplexityCalculator.complexity(UtilityBase.GetSystem(root, "nestedReduction_02")), 4);
     Assert.assertEquals(ComplexityCalculator.complexity(UtilityBase.GetSystem(root, "nestedReduction_03")), 4);
+  }
+
+  @Test
+  public void testComplexity_03() {
+    final AlphaRoot root = AlphaTestUtil.loadValidFile("transformation-tests/substitute-by-def/autoRestrict1.alpha");
+    final AlphaSystem system = UtilityBase.GetSystem(root, "autoRestrict1a");
+    try {
+      ComplexityCalculator.complexity(system);
+    } catch (final Throwable _t) {
+      if (_t instanceof UnsupportedOperationException) {
+        Assert.assertTrue(true);
+        return;
+      } else {
+        throw Exceptions.sneakyThrow(_t);
+      }
+    }
+    Assert.assertTrue(false);
   }
 }


### PR DESCRIPTION
Fixes issue #46 

Now the complexity calculation step used by simplifying reductions lives in it own class. This will be better if/when it needs to be augmented down the road.