### PR TITLE
Maximal simplification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         org.junit.runner.JUnitCore alpha.model.tests.AlphaShowTest
         org.junit.runner.JUnitCore alpha.model.tests.ComplexityCalculatorTest
         org.junit.runner.JUnitCore alpha.model.tests.transformation.reduction.NormalizeReductionDeepTest
+        org.junit.runner.JUnitCore alpha.model.tests.transformation.reduction.SplitReductionTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.DistributivityTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.FactorOutFromReductionTest
         org.junit.runner.JUnitCore alpha.model.tests.transformations.HigherOrderOperatorTest

--- a/bundles/alpha.model/src/alpha/model/matrix/MatrixOperations.java
+++ b/bundles/alpha.model/src/alpha/model/matrix/MatrixOperations.java
@@ -355,7 +355,27 @@ public class MatrixOperations {
 	public static long[][] columnBind(long[][] A, long[][] newCols) {
 		return columnBind(A, newCols[0].length, newCols);
 	}
-
+	
+	/** 
+	 * Inserts a column of all zeros at the front.
+	 * @param A
+	 * @return
+	 */
+	public static long[][] columnBindToFront(long[][] A) {
+		int nbRows = A.length;
+		int nbCols = (nbRows == 0 || A[0].length == 0) ? 0 : A[0].length; 
+		long[][] B = new long[nbRows][nbCols + 1];
+		
+		for (int i = 0; i < nbRows; i++) {
+			B[i][0] = 0;
+			for (int j = 0; j < nbCols; j++) {
+				B[i][j+1] = A[i][j];
+			}
+		}
+		
+		return B;
+	}
+	
 	/**
 	 * Appends additional columns to an existing matrix.
 	 * 

--- a/bundles/alpha.model/src/alpha/model/transformation/automation/OptimalSimplifyingReductions.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/automation/OptimalSimplifyingReductions.xtend
@@ -90,7 +90,7 @@ class OptimalSimplifyingReductions {
 		originalSystemName = system.name
 		optimizationNum = 0
 		initialComplexity = systemBody.complexity
-		throttle = throttleLimit > 0
+		throttle = limit > 0
 		throttleLimit = limit
 	}
 	

--- a/bundles/alpha.model/src/alpha/model/transformation/automation/OptimalSimplifyingReductions.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/automation/OptimalSimplifyingReductions.xtend
@@ -39,6 +39,9 @@ import static extension alpha.model.util.AlphaUtil.getContainerRoot
 import static extension alpha.model.util.AlphaUtil.getContainerSystemBody
 import static extension alpha.model.util.ISLUtil.dimensionality
 import static extension java.lang.String.format
+import static extension alpha.model.util.AlphaOperatorUtil.hasNoInverse
+import alpha.model.transformation.reduction.SplitReduction
+import fr.irisa.cairn.jnimap.isl.ISLConstraint
 
 /**
  * Implements Algorithm 2 in the Simplifying Reductions paper. The current
@@ -284,6 +287,23 @@ class OptimalSimplifyingReductions {
 	private dispatch def shouldRaiseDependence(AlphaExpression ae) { true }
 	
 	/** 
+	 * Return true if the dimensionality of the reduction body is bigger than the dimensionality
+	 * of the variable on the LHS of the containing equation, and false otherwise
+	 */
+	private def shouldSimplify(AbstractReduceExpression are) {
+		val answerDim = (are.getContainerEquation as StandardEquation).variable.domain.dimensionality
+		val bodyDim = are.body.contextDomain.dimensionality
+		return bodyDim > answerDim
+	}
+	
+	/**
+	 * Return true if shouldSimplify returns true and the reduction operator does not admit an inverse
+	 */
+	private def shouldSplit(AbstractReduceExpression are, boolean shouldSimplify) {
+		shouldSimplify && are.operator.hasNoInverse
+	}
+	
+	/** 
 	 * Creates a list of possible transformations that are valid steps in the DP
 	 * 
 	 */
@@ -293,20 +313,17 @@ class OptimalSimplifyingReductions {
 		
 		val candidates = new LinkedList<DynamicProgrammingStep>();
 		
-		// SimplifyingReductions if body is bigger than answer 
-		val answerDim = (targetRE.getContainerEquation as StandardEquation).variable.domain.dimensionality
-		val bodyDim = targetRE.body.contextDomain.dimensionality
-		if (bodyDim > answerDim) {
+		// SimplifyingReductions 
+		val shouldSimplify = targetRE.shouldSimplify
+		if (shouldSimplify) {
 			val vectors = SimplifyingReductions.generateCandidateReuseVectors(targetRE, SSAR);
 			candidates.addAll(vectors.map[vec | new StepSimplifyingReduction(targetRE, vec, nbParams)])
-			
-			/* TODO - place-holder for max simplification splitting step.
-			 * If vectors is empty but bodyDim is larger than answerDim then there is potentially
-			 * reuse that has not yet been exploited, but can be via splitting.
-			 * The call to generate the DP steps for splitting in this case should go here.
-			 * This comment block should be removed by the PR that introduces the splitting logic,
-			 * which will be done separately. 
-			 */
+		}
+		
+		// Splitting
+		if (targetRE.shouldSplit(shouldSimplify)) {
+			 val splits = SplitReduction.enumerateCandidateSplits(targetRE)
+			 candidates.addAll(splits.map[split | new StepSplitReduction(targetRE, split)])
 		}
 		
 		// Idempotent
@@ -355,6 +372,12 @@ class OptimalSimplifyingReductions {
 		RaiseDependence.apply(re, true)
 		AlphaInternalStateConstructor.recomputeContextDomain(systemBody)
 	}
+	protected dispatch def applyDPStep(ReduceExpression re, StepSplitReduction step) {
+		val equation = re.getContainerEquation
+		SplitReduction.apply(re, step.split)
+		// re is no longer contained in the AST
+		NormalizeReduction.apply(equation)
+	}
 	protected dispatch def applyDPStep(AlphaExpression ae, DynamicProgrammingStep step) {
 		// do nothing
 	}
@@ -372,6 +395,12 @@ class OptimalSimplifyingReductions {
 			re = targetRE	
 		}
 		
+		def String toEqStr() {
+			val eq = re.getContainerEquation
+			val eqVarName = (eq instanceof StandardEquation) ? (eq as StandardEquation).variable.name : null 
+			(eqVarName !== null) ? ' to %s'.format(eqVarName) : ''
+		}
+		
 		abstract def String description();
 	}
 	
@@ -381,9 +410,6 @@ class OptimalSimplifyingReductions {
 		}
 		
 		override description() {
-			val eq = re.getContainerEquation
-			val eqVarName = (eq instanceof StandardEquation) ? (eq as StandardEquation).variable.name : null 
-			val toEqStr = (eqVarName !== null) ? 'to %s'.format(eqVarName) : ''
 			String.format("Optimize equation %s", toEqStr);
 		}
 	}
@@ -397,9 +423,6 @@ class OptimalSimplifyingReductions {
 		}
 		
 		override description() {
-			val eq = re.getContainerEquation
-			val eqVarName = (eq instanceof StandardEquation) ? (eq as StandardEquation).variable.name : null 
-			val toEqStr = (eqVarName !== null) ? ' to %s'.format(eqVarName) : ''
 			String.format("Apply SimplifyingReduction%s with: %s", toEqStr, MatrixOperations.toString(reuseDepNoParams));
 		}
 		
@@ -439,9 +462,6 @@ class OptimalSimplifyingReductions {
 		}
 		
 		override description() {
-			val eq = re.getContainerEquation
-			val eqVarName = (eq instanceof StandardEquation) ? (eq as StandardEquation).variable.name : null 
-			val toEqStr = (eqVarName !== null) ? ' to %s'.format(eqVarName) : ''
 			String.format("Apply ReductionDecomposition%s with %s o %s", toEqStr, outerProjection, innerProjection);
 		}
 	}
@@ -453,6 +473,18 @@ class OptimalSimplifyingReductions {
 		
 		override description() {
 			'Apply RaiseDependence'
+		}
+	}
+	
+	static class StepSplitReduction extends DynamicProgrammingStep {
+		ISLConstraint split
+		new(AbstractReduceExpression targetRE, ISLConstraint split) {
+			super(targetRE)
+			this.split = split
+		}
+		
+		override description() {
+			String.format("Apply SplitReduction%s with %s", toEqStr, split);
 		}
 	}
 	

--- a/bundles/alpha.model/src/alpha/model/transformation/reduction/SplitReduction.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/reduction/SplitReduction.xtend
@@ -25,8 +25,8 @@ import alpha.model.StandardEquation
 
 /**
  * This class carries out the analysis required for splitting from the max 
- * simplification paper. This is primarily intended to be used with
- * OptimalSimplifyingReductions.
+ * simplification paper (https://arxiv.org/abs/2309.11826). This is primarily
+ * intended to be used with OptimalSimplifyingReductions.
  * 
  * 1) "covered" (d-2)-faces:
  *    Given an input reduce expression with a d-dimensional body, we need 

--- a/bundles/alpha.model/src/alpha/model/transformation/reduction/SplitReduction.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/reduction/SplitReduction.xtend
@@ -1,0 +1,222 @@
+package alpha.model.transformation.reduction
+
+import alpha.model.AbstractReduceExpression
+import alpha.model.AlphaExpression
+import alpha.model.AlphaInternalStateConstructor
+import alpha.model.DependenceExpression
+import alpha.model.RestrictExpression
+import alpha.model.transformation.Normalize
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet
+import fr.irisa.cairn.jnimap.isl.ISLConstraint
+import fr.irisa.cairn.jnimap.isl.ISLDimType
+import fr.irisa.cairn.jnimap.isl.ISLMultiAff
+import fr.irisa.cairn.jnimap.isl.JNIPtrBoolean
+import org.eclipse.emf.ecore.util.EcoreUtil
+
+import static alpha.model.factory.AlphaUserFactory.createCaseExpression
+import static alpha.model.factory.AlphaUserFactory.createRestrictExpression
+import static alpha.model.util.AlphaUtil.*
+
+import static extension alpha.model.matrix.MatrixOperations.*
+import static extension alpha.model.util.AffineFunctionOperations.*
+import static extension alpha.model.util.AlphaUtil.copyAE
+
+/**
+ * This class carries out the analysis required for splitting from the max 
+ * simplification paper. This is primarily intended to be used with
+ * OptimalSimplifyingReductions.
+ * 
+ * 1) "covered" (d-2)-faces:
+ *    Given an input reduce expression with a d-dimensional body, we need 
+ *    to compute the (d-2)-dimensional (d-2)-faces of the body that are 
+ *    covered per definition 4.8.
+ * 
+ *    Making splits thru covered (d-2)-faces is an optimization. The usefulness
+ *    of such splits is that it will result in two non-empty pieces. We could
+ *    simply try making splits thru all of (d-2)-faces and only keep the ones
+ *    that result in two non-empty pieces. 
+ * 
+ * 2) Given a reduction with a 1D REUSE space and a (d-2)-face of the reduction 
+ *    body, we need to construct a new constraint that saturates the (d-2)-face 
+ *    and the 1D space.
+ *    We can do this in ISL by taking the linear space of the (d-2)-face and then
+ *    applying the transitive closure of the ILSMultiAff characterizing the null
+ *    space of the highest dependence expression in reduction body. 
+ * 
+ * 3) Given a reduction with a 1D ACCUMULATION space and a (d-2)-face of the reduction 
+ *    body, we need to construct a new constraint that saturates the (d-2)-face 
+ *    and the 1D space.
+ *    We can do this in ISL by taking the linear space of the (d-2)-face and then
+ *    applying the transitive closure of the ILSMultiAff characterizing the projection
+ *    function.
+ *  
+ * 
+ */
+class SplitReduction {
+	
+	public static boolean DEBUG = false
+	
+	private static def void debug(String msg) {
+		if (DEBUG)
+			println("[SplitReduction] " + msg)
+	}
+	
+	/** 
+	 * Transforms the input reduction body into two pieces.
+	 * Requires that the context domain of the body be a single polyhedron.
+	 * This is achieved simply replacing the body with a case expression involving
+	 * two branches. Each branch has the same expression, but are restricted to 
+	 * one side of the split.
+	 * 
+	 * Inputs:
+	 * 		are: reduction expression to be split
+	 *    split: an equality constraint 
+	 * 
+	 * Let DE be the context domain of the expression E.
+	 * Let DS be the half-space defined by the inequality form of the constraint split
+	 * Let DS' be the negation of DS (i.e., the opposite half-space)
+	 * 
+	 * before: reduce(op, f, E)
+	 * after:  reduce(op, f, case {DS : E; DS' : E; })
+	 * 
+	 * Note that the reference to are is no longer contained in the AST since the last
+	 * step involves calling PermutationCaseReduce.
+	 */
+	static def apply(AbstractReduceExpression are, ISLConstraint split) {
+		if (are.body.contextDomain.nbBasicSets > 1)
+			throw new Exception("Cannot split a reduction body with multiple basic sets")
+		
+		val DS =  split.aff.toInequalityConstraint.toBasicSet.toSet
+		val const = (split.aff.getConstant - 1).intValue
+		val DSp = split.aff.negate.setConstant(const)
+						   .toInequalityConstraint.toBasicSet.toSet
+		
+		val caseExpr = createCaseExpression()
+		caseExpr.exprs += createRestrictExpression(DS, are.body.copyAE)
+		caseExpr.exprs += createRestrictExpression(DSp, are.body.copyAE)
+		
+		EcoreUtil.replace(are.body, caseExpr)
+		AlphaInternalStateConstructor.recomputeContextDomain(are)
+		Normalize.apply(are)
+		PermutationCaseReduce.apply(are)
+	}
+	
+	
+	/** 
+	 * Returns the list of candidate splits that separate the reduction body into 
+	 * two non-empty pieces.
+	 * These splits are guaranteed to introduce new strong-boundary or strong-invariant
+	 * faces by definition since they are constructed from the accumulation space and
+	 * reuse space accordingly. This requires that the accumulation space and/or the
+	 * reuse space have precisely as 1D null space. If these spaces are larger then 
+	 * candidate splits can be constructed.
+	 * This method is primarily intended to be called by OptimalSimplifyingReductions 
+	 * which systematically applies ReductionDecomposition and DependenceRaising, so this 
+	 * should result in the existence of valid splits at some point in the exploration. 
+	 */
+	static def ISLConstraint[] enumerateCandidateSplits(AbstractReduceExpression are) {
+		
+		val splits = newArrayList
+		
+		val bodyFace = are.facet
+		val bodyDomain = bodyFace.toBasicSet
+		val bodyDim = bodyFace.dimensionality
+		val faces = bodyFace.lattice.getFaces(bodyDim - 2).map[toLinearSpace]
+		
+		// construct splits that saturate the accumulation space
+		val accVec = are.projection.construct1DBasis
+		if (accVec !== null)
+			faces.forEach[f | splits.add(f.copy.constructSplit(accVec))]
+		
+		// construct splits that saturate the reuse space
+		val reuseMaff = are.body.getReuseMaff
+		val reuseVec = if (reuseMaff !== null) reuseMaff.construct1DBasis else null
+		if (reuseVec !== null)
+			faces.forEach[f | splits.add(f.copy.constructSplit(reuseVec))]
+		
+		// remove the splits that don't separate the reduction body into two pieces
+		val usefulSplits = splits.filter[s | s.isUseful(bodyDomain)]
+		
+		usefulSplits.forEach[s | debug('(enumerateCandidateSplits) ' + s.toString)]
+		
+		return usefulSplits
+	}
+	
+	/** 
+	 * Returns true if the constraint splits the set into two non-empty pieces, or
+	 * false otherwise.
+	 */
+	static def isUseful(ISLConstraint split, ISLBasicSet bset) {
+		bset.copy.toSet.subtract(split.copy.toBasicSet.toSet).nbBasicSets == 2
+	}
+	
+	/** 
+	 * This function "extends" the set infinitely along the direction of vec via
+	 * the transitive closure of vec's ISLMap representation. The extended set is 
+	 * guaranteed to have a single equality constraint by construction.
+	 */
+	private static def ISLConstraint constructSplit(ISLBasicSet set, ISLMultiAff vec) {
+		val nbOut = set.dim(ISLDimType.isl_dim_out)
+		val setNoParams = set.dropConstraintsNotInvolvingDims(ISLDimType.isl_dim_out, 0, set.dim(ISLDimType.isl_dim_out))
+		
+		var exact = new JNIPtrBoolean
+		val map = vec.copy.toMap.transitiveClosure(exact)
+		if (!exact.value)
+			throw new Exception('transitive closure should be exact, something is wrong')
+		if (map.nbBasicMaps != 1)
+			throw new Exception('transitive closure should have a single basic map')
+		
+		val hyperplane = renameIndices(setNoParams.copy.apply(map.getBasicMapAt(0)), setNoParams.indexNames)
+			
+		val eqConstraints = hyperplane.constraints
+			.filter[isEquality]
+			.filter[involvesDims(ISLDimType.isl_dim_out, 0, nbOut)]
+		if (eqConstraints.size != 1)
+			throw new Exception('splitting hyperplane should have a single equality constraint')
+		
+		val splitConstraint = eqConstraints.get(0)
+		splitConstraint
+	}
+	
+	/** 
+	 * Returns the 1D vector that spans the null space of the input ISLMultiAff.
+	 * maff is required to have exactly one fewer output dimension than input
+	 * dimensions.
+	 */
+	static def ISLMultiAff construct1DBasis(ISLMultiAff maff) {
+		val nbIn = maff.dim(ISLDimType.isl_dim_in)
+		val nbOut = maff.dim(ISLDimType.isl_dim_out)
+		val nbParam = maff.dim(ISLDimType.isl_dim_param)
+		
+		if (nbIn - nbOut != 1) {
+			return null
+		}
+		
+		val kernel = maff.copy
+			.dropDims(ISLDimType.isl_dim_param, 0, nbParam)
+			.computeKernel
+			
+		if (kernel.transpose.length != 1)
+			throw new Exception("Input maff does not have a 1D null space.")
+		
+		val mat = columnBind(columnBindToFront(createIdentity(nbIn, nbIn)), kernel)
+		
+		val outMaff = mat.toMatrix(maff.space.paramNames, maff.space.inputNames, false, true)
+						.toMultiAff
+		
+		return outMaff
+	}
+	
+	/** 
+	 * Returns the ISLSet characterizing the null-space of the dependence function in 
+	 * the reduction body.
+	 * These dispatch methods should match eventually since OptimalSimplifyingReductions
+	 * systematically calls ReductionDecomposition and RaiseDependence
+	 * */
+	static def dispatch getReuseMaff(RestrictExpression re) { getReuseMaff(re, re.expr)}
+	static def dispatch getReuseMaff(RestrictExpression re, DependenceExpression de) { de.function }
+	static def dispatch getReuseMaff(RestrictExpression re, AlphaExpression ae) { null }
+	static def dispatch getReuseMaff(DependenceExpression de) { de.function }
+	static def dispatch getReuseMaff(AlphaExpression ae) { null }
+	
+}

--- a/bundles/alpha.model/src/alpha/model/util/AlphaOperatorUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AlphaOperatorUtil.xtend
@@ -38,6 +38,10 @@ class AlphaOperatorUtil {
 		}
 	}
 	
+	static def boolean hasNoInverse(REDUCTION_OP op) {
+		return !hasInverse(op)
+	}
+	
 	static def BINARY_OP reductionOPtoBinaryInverseOP(REDUCTION_OP op) {
 		switch (op) {
 			case MIN,

--- a/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
@@ -9,24 +9,26 @@ import alpha.model.AlphaSystem
 import alpha.model.AlphaVisitable
 import alpha.model.Equation
 import alpha.model.SystemBody
+import fr.irisa.cairn.jnimap.isl.ISLAff
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet
+import fr.irisa.cairn.jnimap.isl.ISLDimType
 import fr.irisa.cairn.jnimap.isl.ISLErrorException
 import fr.irisa.cairn.jnimap.isl.ISLFactory
-import fr.irisa.cairn.jnimap.isl.JNIISLTools
-import java.util.LinkedList
-import java.util.List
-import java.util.function.Consumer
-import java.util.function.Supplier
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider
-import org.eclipse.xtext.naming.IQualifiedNameProvider
-import fr.irisa.cairn.jnimap.isl.ISLDimType
 import fr.irisa.cairn.jnimap.isl.ISLMap
 import fr.irisa.cairn.jnimap.isl.ISLMultiAff
 import fr.irisa.cairn.jnimap.isl.ISLPWQPolynomial
 import fr.irisa.cairn.jnimap.isl.ISLQPolynomial
 import fr.irisa.cairn.jnimap.isl.ISLSet
 import fr.irisa.cairn.jnimap.isl.ISLUnionMap
-import fr.irisa.cairn.jnimap.isl.ISLAff
+import fr.irisa.cairn.jnimap.isl.JNIISLTools
+import java.util.LinkedList
+import java.util.List
+import java.util.function.Consumer
+import java.util.function.Supplier
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.util.EcoreUtil.Copier
+import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider
+import org.eclipse.xtext.naming.IQualifiedNameProvider
 
 /**
  * Utility methods for analysis and transformation of Alpha programs.
@@ -34,6 +36,16 @@ import fr.irisa.cairn.jnimap.isl.ISLAff
  */
 class AlphaUtil {
 	
+	/**
+	 * Returns a self-contained copy of the eObject.
+	 */
+	static def <T extends EObject> T copyAE(T eObject) {
+		val Copier copier = new Copier();
+		val EObject result = copier.copy(eObject);
+		copier.copyReferences();
+		val T t = result as T;
+		return t;
+	}
 	
 	/**
 	 * Given a name candidate, ensures that it does not conflict
@@ -262,7 +274,16 @@ class AlphaUtil {
 	static def renameIndices(ISLSet set) {
 		return renameIndices(set, set.defaultDimNames)
 	}
-	
+	static def renameIndices(ISLBasicSet set, List<String> names) {
+		val n = set.getNbIndices()
+		var res = set;
+		if (n > names.length) throw new RuntimeException("Need n or more index names to rename n-d space.");
+		for (i : 0..<n) {
+			res = res.setDimName(ISLDimType.isl_dim_set, i, names.get(i))
+		}
+		
+		return res
+	}
 	static def renameIndices(ISLSet set, List<String> names) {
 		val n = set.getNbIndices()
 		var res = set;

--- a/bundles/alpha.model/src/alpha/model/util/ISLUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/ISLUtil.xtend
@@ -31,9 +31,22 @@ class ISLUtil {
 		ISLBasicMap.buildFromString(ISLContext.instance, descriptor)
 	}
 	
-	/** Creates an ISLBasicSet from a string */
+	/** Creates an ISLAff from a string */
 	def static toISLAff(String descriptor) {
 		ISLAff.buildFromString(ISLContext.instance, descriptor)
+	}
+	
+	/** Creates an ISLMultiAff from a string */
+	def static toISLMultiAff(String descriptor) {
+		ISLMultiAff.buildFromString(ISLContext.instance, descriptor)
+	}
+	
+	/** Creates an ISLConstraint from a string */
+	def static toISLConstraint(String descriptor) {
+		val set = ISLBasicSet.buildFromString(ISLContext.instance, descriptor)
+		if (set.constraints.size != 1)
+			throw new Exception('Cannot create an ISLConstraint from a set with multiple constraints')
+		set.getConstraintAt(0)
 	}
 	
 	/** Transposes an ISLMatrix */

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SplitReduction.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SplitReduction.java
@@ -1,0 +1,306 @@
+package alpha.model.transformation.reduction;
+
+import alpha.model.AbstractReduceExpression;
+import alpha.model.AlphaExpression;
+import alpha.model.AlphaInternalStateConstructor;
+import alpha.model.CaseExpression;
+import alpha.model.DependenceExpression;
+import alpha.model.RestrictExpression;
+import alpha.model.factory.AlphaUserFactory;
+import alpha.model.matrix.MatrixOperations;
+import alpha.model.transformation.Normalize;
+import alpha.model.util.AffineFunctionOperations;
+import alpha.model.util.AlphaUtil;
+import alpha.model.util.Face;
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
+import fr.irisa.cairn.jnimap.isl.ISLConstraint;
+import fr.irisa.cairn.jnimap.isl.ISLDimType;
+import fr.irisa.cairn.jnimap.isl.ISLMap;
+import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
+import fr.irisa.cairn.jnimap.isl.ISLSet;
+import fr.irisa.cairn.jnimap.isl.JNIPtrBoolean;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.InputOutput;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
+
+/**
+ * This class carries out the analysis required for splitting from the max
+ * simplification paper. This is primarily intended to be used with
+ * OptimalSimplifyingReductions.
+ * 
+ * 1) "covered" (d-2)-faces:
+ *    Given an input reduce expression with a d-dimensional body, we need
+ *    to compute the (d-2)-dimensional (d-2)-faces of the body that are
+ *    covered per definition 4.8.
+ * 
+ *    Making splits thru covered (d-2)-faces is an optimization. The usefulness
+ *    of such splits is that it will result in two non-empty pieces. We could
+ *    simply try making splits thru all of (d-2)-faces and only keep the ones
+ *    that result in two non-empty pieces.
+ * 
+ * 2) Given a reduction with a 1D REUSE space and a (d-2)-face of the reduction
+ *    body, we need to construct a new constraint that saturates the (d-2)-face
+ *    and the 1D space.
+ *    We can do this in ISL by taking the linear space of the (d-2)-face and then
+ *    applying the transitive closure of the ILSMultiAff characterizing the null
+ *    space of the highest dependence expression in reduction body.
+ * 
+ * 3) Given a reduction with a 1D ACCUMULATION space and a (d-2)-face of the reduction
+ *    body, we need to construct a new constraint that saturates the (d-2)-face
+ *    and the 1D space.
+ *    We can do this in ISL by taking the linear space of the (d-2)-face and then
+ *    applying the transitive closure of the ILSMultiAff characterizing the projection
+ *    function.
+ */
+@SuppressWarnings("all")
+public class SplitReduction {
+  public static boolean DEBUG = false;
+
+  private static void debug(final String msg) {
+    if (SplitReduction.DEBUG) {
+      InputOutput.<String>println(("[SplitReduction] " + msg));
+    }
+  }
+
+  /**
+   * Transforms the input reduction body into two pieces.
+   * Requires that the context domain of the body be a single polyhedron.
+   * This is achieved simply replacing the body with a case expression involving
+   * two branches. Each branch has the same expression, but are restricted to
+   * one side of the split.
+   * 
+   * Inputs:
+   * 		are: reduction expression to be split
+   *    split: an equality constraint
+   * 
+   * Let DE be the context domain of the expression E.
+   * Let DS be the half-space defined by the inequality form of the constraint split
+   * Let DS' be the negation of DS (i.e., the opposite half-space)
+   * 
+   * before: reduce(op, f, E)
+   * after:  reduce(op, f, case {DS : E; DS' : E; })
+   * 
+   * Note that the reference to are is no longer contained in the AST since the last
+   * step involves calling PermutationCaseReduce.
+   */
+  public static void apply(final AbstractReduceExpression are, final ISLConstraint split) {
+    try {
+      int _nbBasicSets = are.getBody().getContextDomain().getNbBasicSets();
+      boolean _greaterThan = (_nbBasicSets > 1);
+      if (_greaterThan) {
+        throw new Exception("Cannot split a reduction body with multiple basic sets");
+      }
+      final ISLSet DS = split.getAff().toInequalityConstraint().toBasicSet().toSet();
+      long _constant = split.getAff().getConstant();
+      final int const_ = Long.valueOf((_constant - 1)).intValue();
+      final ISLSet DSp = split.getAff().negate().setConstant(const_).toInequalityConstraint().toBasicSet().toSet();
+      final CaseExpression caseExpr = AlphaUserFactory.createCaseExpression();
+      EList<AlphaExpression> _exprs = caseExpr.getExprs();
+      RestrictExpression _createRestrictExpression = AlphaUserFactory.createRestrictExpression(DS, AlphaUtil.<AlphaExpression>copyAE(are.getBody()));
+      _exprs.add(_createRestrictExpression);
+      EList<AlphaExpression> _exprs_1 = caseExpr.getExprs();
+      RestrictExpression _createRestrictExpression_1 = AlphaUserFactory.createRestrictExpression(DSp, AlphaUtil.<AlphaExpression>copyAE(are.getBody()));
+      _exprs_1.add(_createRestrictExpression_1);
+      EcoreUtil.replace(are.getBody(), caseExpr);
+      AlphaInternalStateConstructor.recomputeContextDomain(are);
+      Normalize.apply(are);
+      PermutationCaseReduce.apply(are);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+
+  /**
+   * Returns the list of candidate splits that separate the reduction body into
+   * two non-empty pieces.
+   * These splits are guaranteed to introduce new strong-boundary or strong-invariant
+   * faces by definition since they are constructed from the accumulation space and
+   * reuse space accordingly. This requires that the accumulation space and/or the
+   * reuse space have precisely as 1D null space. If these spaces are larger then
+   * candidate splits can be constructed.
+   * This method is primarily intended to be called by OptimalSimplifyingReductions
+   * which systematically applies ReductionDecomposition and DependenceRaising, so this
+   * should result in the existence of valid splits at some point in the exploration.
+   */
+  public static ISLConstraint[] enumerateCandidateSplits(final AbstractReduceExpression are) {
+    final ArrayList<ISLConstraint> splits = CollectionLiterals.<ISLConstraint>newArrayList();
+    final Face bodyFace = are.getFacet();
+    final ISLBasicSet bodyDomain = bodyFace.toBasicSet();
+    final int bodyDim = bodyFace.getDimensionality();
+    final Function1<Face, ISLBasicSet> _function = (Face it) -> {
+      return it.toLinearSpace();
+    };
+    final List<ISLBasicSet> faces = ListExtensions.<Face, ISLBasicSet>map(bodyFace.getLattice().getFaces((bodyDim - 2)), _function);
+    final ISLMultiAff accVec = SplitReduction.construct1DBasis(are.getProjection());
+    if ((accVec != null)) {
+      final Consumer<ISLBasicSet> _function_1 = (ISLBasicSet f) -> {
+        splits.add(SplitReduction.constructSplit(f.copy(), accVec));
+      };
+      faces.forEach(_function_1);
+    }
+    final ISLMultiAff reuseMaff = SplitReduction.getReuseMaff(are.getBody());
+    ISLMultiAff _xifexpression = null;
+    if ((reuseMaff != null)) {
+      _xifexpression = SplitReduction.construct1DBasis(reuseMaff);
+    } else {
+      _xifexpression = null;
+    }
+    final ISLMultiAff reuseVec = _xifexpression;
+    if ((reuseVec != null)) {
+      final Consumer<ISLBasicSet> _function_2 = (ISLBasicSet f) -> {
+        splits.add(SplitReduction.constructSplit(f.copy(), reuseVec));
+      };
+      faces.forEach(_function_2);
+    }
+    final Function1<ISLConstraint, Boolean> _function_3 = (ISLConstraint s) -> {
+      return Boolean.valueOf(SplitReduction.isUseful(s, bodyDomain));
+    };
+    final Iterable<ISLConstraint> usefulSplits = IterableExtensions.<ISLConstraint>filter(splits, _function_3);
+    final Consumer<ISLConstraint> _function_4 = (ISLConstraint s) -> {
+      String _string = s.toString();
+      String _plus = ("(enumerateCandidateSplits) " + _string);
+      SplitReduction.debug(_plus);
+    };
+    usefulSplits.forEach(_function_4);
+    return ((ISLConstraint[])Conversions.unwrapArray(usefulSplits, ISLConstraint.class));
+  }
+
+  /**
+   * Returns true if the constraint splits the set into two non-empty pieces, or
+   * false otherwise.
+   */
+  public static boolean isUseful(final ISLConstraint split, final ISLBasicSet bset) {
+    int _nbBasicSets = bset.copy().toSet().subtract(split.copy().toBasicSet().toSet()).getNbBasicSets();
+    return (_nbBasicSets == 2);
+  }
+
+  /**
+   * This function "extends" the set infinitely along the direction of vec via
+   * the transitive closure of vec's ISLMap representation. The extended set is
+   * guaranteed to have a single equality constraint by construction.
+   */
+  private static ISLConstraint constructSplit(final ISLBasicSet set, final ISLMultiAff vec) {
+    try {
+      ISLConstraint _xblockexpression = null;
+      {
+        final int nbOut = set.dim(ISLDimType.isl_dim_out);
+        final ISLBasicSet setNoParams = set.dropConstraintsNotInvolvingDims(ISLDimType.isl_dim_out, 0, set.dim(ISLDimType.isl_dim_out));
+        JNIPtrBoolean exact = new JNIPtrBoolean();
+        final ISLMap map = vec.copy().toMap().transitiveClosure(exact);
+        if ((!exact.value)) {
+          throw new Exception("transitive closure should be exact, something is wrong");
+        }
+        int _nbBasicMaps = map.getNbBasicMaps();
+        boolean _notEquals = (_nbBasicMaps != 1);
+        if (_notEquals) {
+          throw new Exception("transitive closure should have a single basic map");
+        }
+        final ISLBasicSet hyperplane = AlphaUtil.renameIndices(setNoParams.copy().apply(map.getBasicMapAt(0)), setNoParams.getIndexNames());
+        final Function1<ISLConstraint, Boolean> _function = (ISLConstraint it) -> {
+          return Boolean.valueOf(it.isEquality());
+        };
+        final Function1<ISLConstraint, Boolean> _function_1 = (ISLConstraint it) -> {
+          return Boolean.valueOf(it.involvesDims(ISLDimType.isl_dim_out, 0, nbOut));
+        };
+        final Iterable<ISLConstraint> eqConstraints = IterableExtensions.<ISLConstraint>filter(IterableExtensions.<ISLConstraint>filter(hyperplane.getConstraints(), _function), _function_1);
+        int _size = IterableExtensions.size(eqConstraints);
+        boolean _notEquals_1 = (_size != 1);
+        if (_notEquals_1) {
+          throw new Exception("splitting hyperplane should have a single equality constraint");
+        }
+        final ISLConstraint splitConstraint = ((ISLConstraint[])Conversions.unwrapArray(eqConstraints, ISLConstraint.class))[0];
+        _xblockexpression = splitConstraint;
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+
+  /**
+   * Returns the 1D vector that spans the null space of the input ISLMultiAff.
+   * maff is required to have exactly one fewer output dimension than input
+   * dimensions.
+   */
+  public static ISLMultiAff construct1DBasis(final ISLMultiAff maff) {
+    try {
+      final int nbIn = maff.dim(ISLDimType.isl_dim_in);
+      final int nbOut = maff.dim(ISLDimType.isl_dim_out);
+      final int nbParam = maff.dim(ISLDimType.isl_dim_param);
+      if (((nbIn - nbOut) != 1)) {
+        return null;
+      }
+      final long[][] kernel = AffineFunctionOperations.computeKernel(maff.copy().dropDims(ISLDimType.isl_dim_param, 0, nbParam));
+      int _length = MatrixOperations.transpose(kernel).length;
+      boolean _notEquals = (_length != 1);
+      if (_notEquals) {
+        throw new Exception("Input maff does not have a 1D null space.");
+      }
+      final long[][] mat = MatrixOperations.columnBind(MatrixOperations.columnBindToFront(MatrixOperations.createIdentity(nbIn, nbIn)), kernel);
+      final ISLMultiAff outMaff = MatrixOperations.toMatrix(mat, maff.getSpace().getParamNames(), maff.getSpace().getInputNames(), false, true).toMultiAff();
+      return outMaff;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+
+  /**
+   * Returns the ISLSet characterizing the null-space of the dependence function in
+   * the reduction body.
+   * These dispatch methods should match eventually since OptimalSimplifyingReductions
+   * systematically calls ReductionDecomposition and RaiseDependence
+   */
+  protected static ISLMultiAff _getReuseMaff(final RestrictExpression re) {
+    return SplitReduction.getReuseMaff(re, re.getExpr());
+  }
+
+  protected static ISLMultiAff _getReuseMaff(final RestrictExpression re, final DependenceExpression de) {
+    return de.getFunction();
+  }
+
+  protected static ISLMultiAff _getReuseMaff(final RestrictExpression re, final AlphaExpression ae) {
+    return null;
+  }
+
+  protected static ISLMultiAff _getReuseMaff(final DependenceExpression de) {
+    return de.getFunction();
+  }
+
+  protected static ISLMultiAff _getReuseMaff(final AlphaExpression ae) {
+    return null;
+  }
+
+  public static ISLMultiAff getReuseMaff(final AlphaExpression de) {
+    if (de instanceof DependenceExpression) {
+      return _getReuseMaff((DependenceExpression)de);
+    } else if (de instanceof RestrictExpression) {
+      return _getReuseMaff((RestrictExpression)de);
+    } else if (de != null) {
+      return _getReuseMaff(de);
+    } else {
+      throw new IllegalArgumentException("Unhandled parameter types: " +
+        Arrays.<Object>asList(de).toString());
+    }
+  }
+
+  public static ISLMultiAff getReuseMaff(final RestrictExpression re, final AlphaExpression de) {
+    if (de instanceof DependenceExpression) {
+      return _getReuseMaff(re, (DependenceExpression)de);
+    } else if (de != null) {
+      return _getReuseMaff(re, de);
+    } else {
+      throw new IllegalArgumentException("Unhandled parameter types: " +
+        Arrays.<Object>asList(re, de).toString());
+    }
+  }
+}

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SplitReduction.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SplitReduction.java
@@ -38,8 +38,8 @@ import org.eclipse.xtext.xbase.lib.ListExtensions;
 
 /**
  * This class carries out the analysis required for splitting from the max
- * simplification paper. This is primarily intended to be used with
- * OptimalSimplifyingReductions.
+ * simplification paper (https://arxiv.org/abs/2309.11826). This is primarily
+ * intended to be used with OptimalSimplifyingReductions.
  * 
  * 1) "covered" (d-2)-faces:
  *    Given an input reduce expression with a d-dimensional body, we need

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SplitReduction.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SplitReduction.java
@@ -49,9 +49,8 @@ import org.eclipse.xtext.xbase.lib.ListExtensions;
  *    Making splits thru covered (d-2)-faces is an optimization. The usefulness
  *    of such splits is that it will result in two non-empty pieces. We could
  *    simply try making splits thru all of (d-2)-faces and only keep the ones
- *    that result in two non-empty pieces.
- * 
- *    Detecting covered edges is not currently implemented.
+ *    that result in two non-empty pieces. This is what the current implementation
+ *    does. Detecting covered edges is not currently implemented.
  * 
  * 2) Given a reduction with a 1D REUSE space and a (d-2)-face of the reduction
  *    body, we need to construct a new constraint that saturates the (d-2)-face
@@ -170,9 +169,9 @@ public class SplitReduction {
         return SplitReduction.constructSplit(it.copy(), accVec);
       };
       final Function1<ISLConstraint, Boolean> _function_2 = (ISLConstraint s) -> {
-        return Boolean.valueOf((s != null));
+        return Boolean.valueOf((s == null));
       };
-      Iterables.<ISLConstraint>addAll(splits, IterableExtensions.<ISLConstraint>filter(ListExtensions.<ISLBasicSet, ISLConstraint>map(faces, _function_1), _function_2));
+      Iterables.<ISLConstraint>addAll(splits, IterableExtensions.<ISLConstraint>reject(ListExtensions.<ISLBasicSet, ISLConstraint>map(faces, _function_1), _function_2));
     }
     final ISLMultiAff reuseMaff = SplitReduction.getReuseMaff(are.getBody());
     ISLMultiAff _xifexpression_2 = null;
@@ -187,9 +186,9 @@ public class SplitReduction {
         return SplitReduction.constructSplit(it.copy(), reuseVec);
       };
       final Function1<ISLConstraint, Boolean> _function_4 = (ISLConstraint s) -> {
-        return Boolean.valueOf((s != null));
+        return Boolean.valueOf((s == null));
       };
-      Iterables.<ISLConstraint>addAll(splits, IterableExtensions.<ISLConstraint>filter(ListExtensions.<ISLBasicSet, ISLConstraint>map(faces, _function_3), _function_4));
+      Iterables.<ISLConstraint>addAll(splits, IterableExtensions.<ISLConstraint>reject(ListExtensions.<ISLBasicSet, ISLConstraint>map(faces, _function_3), _function_4));
     }
     final Function1<ISLConstraint, Boolean> _function_5 = (ISLConstraint s) -> {
       return Boolean.valueOf(SplitReduction.isUseful(s, bodyDomain));
@@ -218,7 +217,7 @@ public class SplitReduction {
    * the transitive closure of vec's ISLMap representation. The extended set is
    * guaranteed to have a single equality constraint by construction.
    */
-  private static ISLConstraint constructSplit(final ISLBasicSet edge, final ISLMultiAff vec) {
+  public static ISLConstraint constructSplit(final ISLBasicSet edge, final ISLMultiAff vec) {
     try {
       ISLConstraint _xblockexpression = null;
       {

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaOperatorUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaOperatorUtil.java
@@ -62,6 +62,11 @@ public class AlphaOperatorUtil {
     }
   }
 
+  public static boolean hasNoInverse(final REDUCTION_OP op) {
+    boolean _hasInverse = AlphaOperatorUtil.hasInverse(op);
+    return (!_hasInverse);
+  }
+
   public static BINARY_OP reductionOPtoBinaryInverseOP(final REDUCTION_OP op) {
     BINARY_OP _switchResult = null;
     if (op != null) {

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
@@ -12,6 +12,7 @@ import alpha.model.SystemBody;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import fr.irisa.cairn.jnimap.isl.ISLAff;
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
 import fr.irisa.cairn.jnimap.isl.ISLDimType;
 import fr.irisa.cairn.jnimap.isl.ISLErrorException;
 import fr.irisa.cairn.jnimap.isl.ISLFactory;
@@ -32,6 +33,7 @@ import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.xbase.lib.Conversions;
@@ -50,6 +52,17 @@ import org.eclipse.xtext.xbase.lib.ListExtensions;
  */
 @SuppressWarnings("all")
 public class AlphaUtil {
+  /**
+   * Returns a self-contained copy of the eObject.
+   */
+  public static <T extends EObject> T copyAE(final T eObject) {
+    final EcoreUtil.Copier copier = new EcoreUtil.Copier();
+    final EObject result = copier.copy(eObject);
+    copier.copyReferences();
+    final T t = ((T) result);
+    return t;
+  }
+
   /**
    * Given a name candidate, ensures that it does not conflict
    * with existing variables. If a variable is in conflict,
@@ -339,6 +352,21 @@ public class AlphaUtil {
    */
   public static ISLSet renameIndices(final ISLSet set) {
     return AlphaUtil.renameIndices(set, AlphaUtil.defaultDimNames(set));
+  }
+
+  public static ISLBasicSet renameIndices(final ISLBasicSet set, final List<String> names) {
+    final int n = set.getNbIndices();
+    ISLBasicSet res = set;
+    int _length = ((Object[])Conversions.unwrapArray(names, Object.class)).length;
+    boolean _greaterThan = (n > _length);
+    if (_greaterThan) {
+      throw new RuntimeException("Need n or more index names to rename n-d space.");
+    }
+    ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, n, true);
+    for (final Integer i : _doubleDotLessThan) {
+      res = res.setDimName(ISLDimType.isl_dim_set, (i).intValue(), names.get((i).intValue()));
+    }
+    return res;
   }
 
   public static ISLSet renameIndices(final ISLSet set, final List<String> names) {

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/ISLUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/ISLUtil.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.ExclusiveRange;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.Functions.Function2;
@@ -46,10 +47,38 @@ public class ISLUtil {
   }
 
   /**
-   * Creates an ISLBasicSet from a string
+   * Creates an ISLAff from a string
    */
   public static ISLAff toISLAff(final String descriptor) {
     return ISLAff.buildFromString(ISLContext.getInstance(), descriptor);
+  }
+
+  /**
+   * Creates an ISLMultiAff from a string
+   */
+  public static ISLMultiAff toISLMultiAff(final String descriptor) {
+    return ISLMultiAff.buildFromString(ISLContext.getInstance(), descriptor);
+  }
+
+  /**
+   * Creates an ISLConstraint from a string
+   */
+  public static ISLConstraint toISLConstraint(final String descriptor) {
+    try {
+      ISLConstraint _xblockexpression = null;
+      {
+        final ISLBasicSet set = ISLBasicSet.buildFromString(ISLContext.getInstance(), descriptor);
+        int _size = set.getConstraints().size();
+        boolean _notEquals = (_size != 1);
+        if (_notEquals) {
+          throw new Exception("Cannot create an ISLConstraint from a set with multiple constraints");
+        }
+        _xblockexpression = set.getConstraintAt(0);
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
 
   /**

--- a/tests/alpha.model.tests/resources/src-valid/transformation-reduction-tests/split-reduction/splitReduction.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-reduction-tests/split-reduction/splitReduction.alpha
@@ -1,0 +1,17 @@
+affine ex_2d [N]->{ : 10<N }
+	inputs 
+		X : {[i]: 0<=i<=2N}
+	outputs
+		Y : {[i]: 0<=i<=N }
+	let
+		Y[i] = reduce(max, (i,j->i), {: 0<=j<=i and j<=N-i} : X[j]);
+.
+
+affine ex_3d [N]->{ : 10<N }
+		inputs 
+			X : {[k]: 0<=k<=N}
+		outputs
+			Y : {[i,j] : j>=N-i and j>=-2N+2i and 2j<=2N+i }
+		let
+			Y[i,j] = reduce(min, (i,j,k->i,j), {: 0<=k<=2N-2i+j and k<=2N+i-2j and k<=-N+i+j}: X[k]);
+	.

--- a/tests/alpha.model.tests/src/alpha/model/tests/transformation/reduction/SplitReductionTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/transformation/reduction/SplitReductionTest.xtend
@@ -1,0 +1,200 @@
+package alpha.model.tests.transformation.reduction
+
+import alpha.model.ReduceExpression
+import org.junit.Test
+
+import static alpha.commands.UtilityBase.GetEquation
+import static alpha.commands.UtilityBase.GetSystem
+import static alpha.model.tests.util.AlphaTestUtil.loadValidFile
+import static org.junit.Assert.*
+
+import static extension alpha.model.transformation.reduction.SplitReduction.construct1DBasis
+import static extension alpha.model.transformation.reduction.SplitReduction.constructSplit
+import static extension alpha.model.transformation.reduction.SplitReduction.enumerateCandidateSplits
+import static extension alpha.model.transformation.reduction.SplitReduction.isUseful
+import static extension alpha.model.util.ISLUtil.toISLBasicSet
+import static extension alpha.model.util.ISLUtil.toISLConstraint
+import static extension alpha.model.util.ISLUtil.toISLMultiAff
+
+class SplitReductionTest {
+	
+	/*
+	 * construct1DBasis tests
+	 * 
+	 * Given a reduce expression of the form:
+	 *   reduce(op, fp, fd@(E))
+	 * 
+	 * where:
+	 *   fp is the projection function (characterizing accumulation)
+	 *   fd is the dependence function (characterizing reuse)
+	 * 
+	 * When the null space of fp or fd is 1D, the construct1DBasis function  
+	 * constructs a new ISLMultiAff that points "along" this 1D null space.
+	 * The vector of the constant terms in each output dimension can be 
+	 * viewed as a basis vector that spans the 1D null space.
+	 * 
+	 * For example: 
+	 * 
+	 * If fp (or fd) is (i,j->i) then construct1DBasis should return
+	 * the following ISLMultiAff:
+	 *   {[i,j]->[i,j+1]}
+	 * because the vector of output dim's constants is <0,1> which spans
+	 * the null space of (i,j->i).
+	 * 
+	 * If fp (or fd) is (i,j->i+j) then it should return:
+	 *   {[i,j]->[i+1,j-1]}
+	 * and <1,-1> spans the null space of (i,j->i+j)
+	 * 
+	 * If fp (or fd) is (i,j,k->i+j) then it should return:
+	 *   null
+	 * becuase the null space of (i,j,k->i+j) is 2D and can't be represented
+	 * by a 1D basis.
+	 * 
+	 */ 
+	
+	@Test
+	def void construct1DBasis_01() {
+		val maff = '[N]->{[i,j,k]->[i,j]}'.toISLMultiAff
+		val basis = maff.construct1DBasis.affs.map[getConstant]
+		assertEquals(basis.toString, '[0, 0, 1]')
+	}
+	
+	@Test
+	def void construct1DBasis_02() {
+		val maff = '[N]->{[i,j,k]->[i,7j-k]}'.toISLMultiAff
+		val basis = maff.construct1DBasis.affs.map[getConstant]
+		assertEquals(basis.toString, '[0, 1, 7]')
+	}
+	
+	@Test
+	def void construct1DBasis_03() {
+		val maff = '[N]->{[i,j,k]->[i]}'.toISLMultiAff
+		val basis = maff.construct1DBasis
+		assertNull(basis)
+	}
+	
+	/*
+	 * constructSplit tests
+	 * 
+	 * Given an ISLMaff and an ISLBasicSet, constructSplit "extends" the
+	 * basic set infinitely along the direction encoded by the maff. The 
+	 * extension is performed by applying the transitive closure of maff 
+	 * to the basicSet. This has the effect of increasing the dimensionality
+	 * of the basicSet by one, assuming that the space spanned by the 
+	 * transitive closure is not already saturated by the set. If the set 
+	 * saturates the transitive closure then "null" is returned.
+	 * 
+	 * Examples:
+	 * 
+	 * 1) Given the following:
+	 *    basicSet: [N]->{[i,j] : i=N and j=0}
+	 *    maff: [N]->{[i,j]->[i,j+1]}
+	 * 
+	 * Here the transitive closure of maff is {[i,j]->[i,o1]} (i.e., j is 
+	 * unbounded). The following basicSet is returned:
+	 *    [N]->{[i,j] : i=N}
+	 * Notice the input set is 0D and the output is 1D.
+	 * 
+	 * 2) Given the following:
+	 *    basicSet: [N]->{[i,j,k] : i=0 and j=0}
+	 *    maff: [N]->{[i,j,k]->[i+1,j+1,k]}
+	 * 
+	 * Geometrically, basicSet represents the k-axis and we are extending this
+	 * by the vector <1,1,0>, which gives the 2D plane parallel to the k-axis
+	 * intesecting the line i=j in the ij-plane. The following set is returned:
+	 *    [N]->{[i,j,k] : i=j}
+	 * 
+	 * 3) Given the following:
+	 *    basicSet: [N]->{[i,j,k] : i=0 and j=0}
+	 *    maff: [N]->{[i,j,k]->[i,j,k+1]}
+	 * 
+	 * Here, the set saturates the transitive closure. The basicSet is same as
+	 * example 2. Extending this set by the vector <0,0,1> leaves the same set
+	 * because here we try to extend the k-axis along the k direction. The
+	 * following is returned:
+	 *    null
+	 */
+	 
+	@Test
+	def void constructSplit_00() {
+		val bset = '[N]->{[i,j] : i=N and j=0}'.toISLBasicSet
+		val maff = '[N]->{[i,j]->[i,j+1]}'.toISLMultiAff
+		assertEquals(bset.constructSplit(maff).toString, '[N] -> { [i, j] : -N + i = 0 }')
+	}
+	
+	@Test
+	def void constructSplit_01() {
+		val bset = '[N]->{[i,j] : i=N and j=0}'.toISLBasicSet
+		val maff = '[N]->{[i,j]->[i+1,j]}'.toISLMultiAff
+		assertEquals(bset.constructSplit(maff).toString, '[N] -> { [i, j] : j = 0 }')
+	}
+	
+	@Test
+	def void constructSplit_02() {
+		val bset = '[N]->{[i,j,k] : i=0 and j=0}'.toISLBasicSet
+		val maff = '[N]->{[i,j,k]->[i+1,j+1,k]}'.toISLMultiAff
+		assertEquals(bset.constructSplit(maff).toString, '[N] -> { [i, j, k] : -i + j = 0 }')
+	}
+	
+	@Test
+	def void constructSplit_03() {
+		val bset = '[N]->{[i,j,k] : i=0 and j=0}'.toISLBasicSet
+		val maff = '[N]->{[i,j,k]->[i,j,k+1]}'.toISLMultiAff
+		assertNull(bset.constructSplit(maff))
+	}
+	
+	/*
+	 * isUseful tests
+	 * 
+	 * Given an ISLConstraint and an ISLBasicSet this function should return
+	 * true if there are points in the set on both sides of the constraint 
+	 * (i.e., the constraint actually splits the set into two non-empty pieces)
+	 */
+	 
+	 @Test
+	 def void isUseful_00() {
+	 	val split1 = '[N]->{[i,j] : i=0}'.toISLConstraint
+	 	val split2 = '[N]->{[i,j] : i=N}'.toISLConstraint
+	 	val split3 = '[N]->{[i,j] : j=0}'.toISLConstraint
+	 	val split4 = '[N]->{[i,j] : j=N}'.toISLConstraint
+	 	val split5 = '[N]->{[i,j] : j=N-i}'.toISLConstraint
+	 	val bset = '[N]->{[i,j] : 0<=j<=i<N}'.toISLBasicSet
+	 	
+	 	assertFalse(split1.isUseful(bset))
+	 	assertFalse(split2.isUseful(bset))
+	 	assertFalse(split3.isUseful(bset))
+	 	assertFalse(split4.isUseful(bset))
+	 	assertTrue(split5.isUseful(bset)) 
+	 }
+	
+	/*
+	 * enumerateCandidateSplits tests
+	 * 
+	 * Given a reduceExpression, this function reports all of the useful splits
+	 * that can be constructed. Each split must saturate either the null space of
+	 * the projection function or the dependence function (charaterizing the 
+	 * reuse space). These tests simply assert that the number of splits matches
+	 * what is expected.
+	 */
+	
+	@Test
+	def void enumerateCandidateSplits_00() {
+		val root = loadValidFile('transformation-reduction-tests/split-reduction/splitReduction.alpha')
+		val systemBody = GetSystem(root, 'ex_2d').systemBodies.get(0)
+		val reduceExpr = GetEquation(systemBody, 'Y').expr as ReduceExpression
+		val splits = reduceExpr.enumerateCandidateSplits
+		
+		assertEquals(splits.size, 1)
+	}
+	
+	@Test
+	def void enumerateCandidateSplits_01() {
+		val root = loadValidFile('transformation-reduction-tests/split-reduction/splitReduction.alpha')
+		val systemBody = GetSystem(root, 'ex_3d').systemBodies.get(0)
+		val reduceExpr = GetEquation(systemBody, 'Y').expr as ReduceExpression
+		val splits = reduceExpr.enumerateCandidateSplits
+		
+		assertEquals(splits.size, 3)
+	}
+	
+}

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/SplitReductionTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/SplitReductionTest.java
@@ -1,0 +1,202 @@
+package alpha.model.tests.transformation.reduction;
+
+import alpha.commands.UtilityBase;
+import alpha.model.AlphaExpression;
+import alpha.model.AlphaRoot;
+import alpha.model.ReduceExpression;
+import alpha.model.SystemBody;
+import alpha.model.tests.util.AlphaTestUtil;
+import alpha.model.transformation.reduction.SplitReduction;
+import alpha.model.util.ISLUtil;
+import fr.irisa.cairn.jnimap.isl.ISLAff;
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
+import fr.irisa.cairn.jnimap.isl.ISLConstraint;
+import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
+import java.util.List;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class SplitReductionTest {
+  /**
+   * construct1DBasis tests
+   * 
+   * Given a reduce expression of the form:
+   *   reduce(op, fp, fd@(E))
+   * 
+   * where:
+   *   fp is the projection function (characterizing accumulation)
+   *   fd is the dependence function (characterizing reuse)
+   * 
+   * When the null space of fp or fd is 1D, the construct1DBasis function
+   * constructs a new ISLMultiAff that points "along" this 1D null space.
+   * The vector of the constant terms in each output dimension can be
+   * viewed as a basis vector that spans the 1D null space.
+   * 
+   * For example:
+   * 
+   * If fp (or fd) is (i,j->i) then construct1DBasis should return
+   * the following ISLMultiAff:
+   *   {[i,j]->[i,j+1]}
+   * because the vector of output dim's constants is <0,1> which spans
+   * the null space of (i,j->i).
+   * 
+   * If fp (or fd) is (i,j->i+j) then it should return:
+   *   {[i,j]->[i+1,j-1]}
+   * and <1,-1> spans the null space of (i,j->i+j)
+   * 
+   * If fp (or fd) is (i,j,k->i+j) then it should return:
+   *   null
+   * becuase the null space of (i,j,k->i+j) is 2D and can't be represented
+   * by a 1D basis.
+   */
+  @Test
+  public void construct1DBasis_01() {
+    final ISLMultiAff maff = ISLUtil.toISLMultiAff("[N]->{[i,j,k]->[i,j]}");
+    final Function1<ISLAff, Long> _function = (ISLAff it) -> {
+      return Long.valueOf(it.getConstant());
+    };
+    final List<Long> basis = ListExtensions.<ISLAff, Long>map(SplitReduction.construct1DBasis(maff).getAffs(), _function);
+    Assert.assertEquals(basis.toString(), "[0, 0, 1]");
+  }
+
+  @Test
+  public void construct1DBasis_02() {
+    final ISLMultiAff maff = ISLUtil.toISLMultiAff("[N]->{[i,j,k]->[i,7j-k]}");
+    final Function1<ISLAff, Long> _function = (ISLAff it) -> {
+      return Long.valueOf(it.getConstant());
+    };
+    final List<Long> basis = ListExtensions.<ISLAff, Long>map(SplitReduction.construct1DBasis(maff).getAffs(), _function);
+    Assert.assertEquals(basis.toString(), "[0, 1, 7]");
+  }
+
+  @Test
+  public void construct1DBasis_03() {
+    final ISLMultiAff maff = ISLUtil.toISLMultiAff("[N]->{[i,j,k]->[i]}");
+    final ISLMultiAff basis = SplitReduction.construct1DBasis(maff);
+    Assert.assertNull(basis);
+  }
+
+  /**
+   * constructSplit tests
+   * 
+   * Given an ISLMaff and an ISLBasicSet, constructSplit "extends" the
+   * basic set infinitely along the direction encoded by the maff. The
+   * extension is performed by applying the transitive closure of maff
+   * to the basicSet. This has the effect of increasing the dimensionality
+   * of the basicSet by one, assuming that the space spanned by the
+   * transitive closure is not already saturated by the set. If the set
+   * saturates the transitive closure then "null" is returned.
+   * 
+   * Examples:
+   * 
+   * 1) Given the following:
+   *    basicSet: [N]->{[i,j] : i=N and j=0}
+   *    maff: [N]->{[i,j]->[i,j+1]}
+   * 
+   * Here the transitive closure of maff is {[i,j]->[i,o1]} (i.e., j is
+   * unbounded). The following basicSet is returned:
+   *    [N]->{[i,j] : i=N}
+   * Notice the input set is 0D and the output is 1D.
+   * 
+   * 2) Given the following:
+   *    basicSet: [N]->{[i,j,k] : i=0 and j=0}
+   *    maff: [N]->{[i,j,k]->[i+1,j+1,k]}
+   * 
+   * Geometrically, basicSet represents the k-axis and we are extending this
+   * by the vector <1,1,0>, which gives the 2D plane parallel to the k-axis
+   * intesecting the line i=j in the ij-plane. The following set is returned:
+   *    [N]->{[i,j,k] : i=j}
+   * 
+   * 3) Given the following:
+   *    basicSet: [N]->{[i,j,k] : i=0 and j=0}
+   *    maff: [N]->{[i,j,k]->[i,j,k+1]}
+   * 
+   * Here, the set saturates the transitive closure. The basicSet is same as
+   * example 2. Extending this set by the vector <0,0,1> leaves the same set
+   * because here we try to extend the k-axis along the k direction. The
+   * following is returned:
+   *    null
+   */
+  @Test
+  public void constructSplit_00() {
+    final ISLBasicSet bset = ISLUtil.toISLBasicSet("[N]->{[i,j] : i=N and j=0}");
+    final ISLMultiAff maff = ISLUtil.toISLMultiAff("[N]->{[i,j]->[i,j+1]}");
+    Assert.assertEquals(SplitReduction.constructSplit(bset, maff).toString(), "[N] -> { [i, j] : -N + i = 0 }");
+  }
+
+  @Test
+  public void constructSplit_01() {
+    final ISLBasicSet bset = ISLUtil.toISLBasicSet("[N]->{[i,j] : i=N and j=0}");
+    final ISLMultiAff maff = ISLUtil.toISLMultiAff("[N]->{[i,j]->[i+1,j]}");
+    Assert.assertEquals(SplitReduction.constructSplit(bset, maff).toString(), "[N] -> { [i, j] : j = 0 }");
+  }
+
+  @Test
+  public void constructSplit_02() {
+    final ISLBasicSet bset = ISLUtil.toISLBasicSet("[N]->{[i,j,k] : i=0 and j=0}");
+    final ISLMultiAff maff = ISLUtil.toISLMultiAff("[N]->{[i,j,k]->[i+1,j+1,k]}");
+    Assert.assertEquals(SplitReduction.constructSplit(bset, maff).toString(), "[N] -> { [i, j, k] : -i + j = 0 }");
+  }
+
+  @Test
+  public void constructSplit_03() {
+    final ISLBasicSet bset = ISLUtil.toISLBasicSet("[N]->{[i,j,k] : i=0 and j=0}");
+    final ISLMultiAff maff = ISLUtil.toISLMultiAff("[N]->{[i,j,k]->[i,j,k+1]}");
+    Assert.assertNull(SplitReduction.constructSplit(bset, maff));
+  }
+
+  /**
+   * isUseful tests
+   * 
+   * Given an ISLConstraint and an ISLBasicSet this function should return
+   * true if there are points in the set on both sides of the constraint
+   * (i.e., the constraint actually splits the set into two non-empty pieces)
+   */
+  @Test
+  public void isUseful_00() {
+    final ISLConstraint split1 = ISLUtil.toISLConstraint("[N]->{[i,j] : i=0}");
+    final ISLConstraint split2 = ISLUtil.toISLConstraint("[N]->{[i,j] : i=N}");
+    final ISLConstraint split3 = ISLUtil.toISLConstraint("[N]->{[i,j] : j=0}");
+    final ISLConstraint split4 = ISLUtil.toISLConstraint("[N]->{[i,j] : j=N}");
+    final ISLConstraint split5 = ISLUtil.toISLConstraint("[N]->{[i,j] : j=N-i}");
+    final ISLBasicSet bset = ISLUtil.toISLBasicSet("[N]->{[i,j] : 0<=j<=i<N}");
+    Assert.assertFalse(SplitReduction.isUseful(split1, bset));
+    Assert.assertFalse(SplitReduction.isUseful(split2, bset));
+    Assert.assertFalse(SplitReduction.isUseful(split3, bset));
+    Assert.assertFalse(SplitReduction.isUseful(split4, bset));
+    Assert.assertTrue(SplitReduction.isUseful(split5, bset));
+  }
+
+  /**
+   * enumerateCandidateSplits tests
+   * 
+   * Given a reduceExpression, this function reports all of the useful splits
+   * that can be constructed. Each split must saturate either the null space of
+   * the projection function or the dependence function (charaterizing the
+   * reuse space). These tests simply assert that the number of splits matches
+   * what is expected.
+   */
+  @Test
+  public void enumerateCandidateSplits_00() {
+    final AlphaRoot root = AlphaTestUtil.loadValidFile("transformation-reduction-tests/split-reduction/splitReduction.alpha");
+    final SystemBody systemBody = UtilityBase.GetSystem(root, "ex_2d").getSystemBodies().get(0);
+    AlphaExpression _expr = UtilityBase.GetEquation(systemBody, "Y").getExpr();
+    final ReduceExpression reduceExpr = ((ReduceExpression) _expr);
+    final ISLConstraint[] splits = SplitReduction.enumerateCandidateSplits(reduceExpr);
+    Assert.assertEquals(((List<ISLConstraint>)Conversions.doWrapArray(splits)).size(), 1);
+  }
+
+  @Test
+  public void enumerateCandidateSplits_01() {
+    final AlphaRoot root = AlphaTestUtil.loadValidFile("transformation-reduction-tests/split-reduction/splitReduction.alpha");
+    final SystemBody systemBody = UtilityBase.GetSystem(root, "ex_3d").getSystemBodies().get(0);
+    AlphaExpression _expr = UtilityBase.GetEquation(systemBody, "Y").getExpr();
+    final ReduceExpression reduceExpr = ((ReduceExpression) _expr);
+    final ISLConstraint[] splits = SplitReduction.enumerateCandidateSplits(reduceExpr);
+    Assert.assertEquals(((List<ISLConstraint>)Conversions.doWrapArray(splits)).size(), 3);
+  }
+}


### PR DESCRIPTION
This implements the splitting steps for simplification that may be required when the reduction operator does not admit an inverse. This involves small changes the OptimalSimplifyingReductions, a new dynamic programming step for splitting is introduced.

The bulk of the new logic is in alpha.model.transformation.reduction.SplitReduction. Essentially, given a reduce expression with 1D accumulation and/or 1D reuse space, we construct the list of useful candidate splits for simplification. The definition of a useful split is one that both:
* separates the reduction body into two non-empty pieces
* exposes a new boundary or invariant face

Then a new candidate DPStep is inserted into the OptimalSimplifyingReductions flow for each.

See the comments in alpha.model.transformation.reduction.SplitReduction and the corresponding test file for more detail on how it is supposed to work.

Resolves issue #43 