### PR TITLE
Fix normalization of binary expressions with multiple case expressions

### DIFF
--- a/tests/alpha.model.tests/resources/src-valid/transformation-tests/normalize/multipleCaseExprs.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/transformation-tests/normalize/multipleCaseExprs.alpha
@@ -1,0 +1,15 @@
+affine binExprWithCases [N] -> {: N > 5}
+	inputs
+		X : {[i] : N-3<=i<2N}
+	outputs
+		Y : {[i]: 0<=i<=N}
+	let
+		Y[i] = case {
+			{:0=i  } : 0[];
+			{:0<i<N} : 12[];
+			{:  i=N} : 1[];
+		} + case {
+			{:  i<N-3} : 5[];
+			X[i];
+		};
+.


### PR DESCRIPTION
Fixes issues #55 and #44.

Previously, normalize did not handle binary expressions with multiple case expressions correctly. Now it does, and correctly transforms this:
```
affine test11 [N] -> {  : N >= 6 }
	inputs
		X : {[i]: -3 + N <= i < 2N }
	outputs
		Y : {[i]: 0 <= i <= N }
	when {  : N >= 6 } let
		Y[i] = (case  {
			{: i = 0 } : 0[];
			{: 0 < i < N } : 12[];
			{: i = N } : 1[];
		} + case  {
			{: i <= -4 + N } : 5[];
			X[i];
		});
.
```
into this:
```
affine test11 [N] -> {  : N >= 6 }
	inputs
		X : {[i]: -3 + N <= i < 2N }
	outputs
		Y : {[i]: 0 <= i <= N }
	when {  : N >= 6 } let
		Y[i] = case  {
			{: i = 0 } : (0[] + 5[]);
			{: 0 < i <= -4 + N } : (12[] + 5[]);
			{: -3 + N <= i < N } : (12[] + X);
			{: i = N } : (1[] + X);
		};
.
```