### PR TITLE
Codegen int or float

### DIFF
--- a/bundles/alpha.codegen/model/simpleC.xcore
+++ b/bundles/alpha.codegen/model/simpleC.xcore
@@ -60,6 +60,9 @@ enum BaseDataType {
 	/** A single ASCII character. */
 	CHAR,
 	
+	/** A regular length integer. */
+	INT,
+	
 	/** A long integer. */
 	LONG,
 	

--- a/bundles/alpha.codegen/model/simpleC.xcore
+++ b/bundles/alpha.codegen/model/simpleC.xcore
@@ -67,7 +67,10 @@ enum BaseDataType {
 	LONG,
 	
 	/** An IEEE floating point value. */
-	FLOAT
+	FLOAT,
+	
+	/** An IEEE double-precision floating point value. */
+	DOUBLE
 }
 
 /** Represents a data type which may or may not be a pointer. */

--- a/bundles/alpha.codegen/src-gen/alpha/codegen/BaseDataType.java
+++ b/bundles/alpha.codegen/src-gen/alpha/codegen/BaseDataType.java
@@ -88,7 +88,20 @@ public enum BaseDataType implements Enumerator {
 	 * @generated
 	 * @ordered
 	 */
-	FLOAT(0, "FLOAT", "FLOAT");
+	FLOAT(0, "FLOAT", "FLOAT"),
+
+	/**
+	 * The '<em><b>DOUBLE</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * * An IEEE double-precision floating point value.
+	 * <!-- end-model-doc -->
+	 * @see #DOUBLE_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	DOUBLE(0, "DOUBLE", "DOUBLE");
 
 	/**
 	 * The '<em><b>VOID</b></em>' literal value.
@@ -161,6 +174,20 @@ public enum BaseDataType implements Enumerator {
 	public static final int FLOAT_VALUE = 0;
 
 	/**
+	 * The '<em><b>DOUBLE</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * * An IEEE double-precision floating point value.
+	 * <!-- end-model-doc -->
+	 * @see #DOUBLE
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int DOUBLE_VALUE = 0;
+
+	/**
 	 * An array of all the '<em><b>Base Data Type</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -173,6 +200,7 @@ public enum BaseDataType implements Enumerator {
 			INT,
 			LONG,
 			FLOAT,
+			DOUBLE,
 		};
 
 	/**

--- a/bundles/alpha.codegen/src-gen/alpha/codegen/BaseDataType.java
+++ b/bundles/alpha.codegen/src-gen/alpha/codegen/BaseDataType.java
@@ -52,6 +52,19 @@ public enum BaseDataType implements Enumerator {
 	CHAR(0, "CHAR", "CHAR"),
 
 	/**
+	 * The '<em><b>INT</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * * A regular length integer.
+	 * <!-- end-model-doc -->
+	 * @see #INT_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	INT(0, "INT", "INT"),
+
+	/**
 	 * The '<em><b>LONG</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -106,6 +119,20 @@ public enum BaseDataType implements Enumerator {
 	public static final int CHAR_VALUE = 0;
 
 	/**
+	 * The '<em><b>INT</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * * A regular length integer.
+	 * <!-- end-model-doc -->
+	 * @see #INT
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int INT_VALUE = 0;
+
+	/**
 	 * The '<em><b>LONG</b></em>' literal value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -143,6 +170,7 @@ public enum BaseDataType implements Enumerator {
 		new BaseDataType[] {
 			VOID,
 			CHAR,
+			INT,
 			LONG,
 			FLOAT,
 		};

--- a/bundles/alpha.codegen/src-gen/alpha/codegen/impl/CodegenPackageImpl.java
+++ b/bundles/alpha.codegen/src-gen/alpha/codegen/impl/CodegenPackageImpl.java
@@ -1472,6 +1472,7 @@ public class CodegenPackageImpl extends EPackageImpl implements CodegenPackage {
 		initEEnum(baseDataTypeEEnum, BaseDataType.class, "BaseDataType");
 		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.VOID);
 		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.CHAR);
+		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.INT);
 		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.LONG);
 		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.FLOAT);
 

--- a/bundles/alpha.codegen/src-gen/alpha/codegen/impl/CodegenPackageImpl.java
+++ b/bundles/alpha.codegen/src-gen/alpha/codegen/impl/CodegenPackageImpl.java
@@ -1475,6 +1475,7 @@ public class CodegenPackageImpl extends EPackageImpl implements CodegenPackage {
 		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.INT);
 		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.LONG);
 		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.FLOAT);
+		addEEnumLiteral(baseDataTypeEEnum, BaseDataType.DOUBLE);
 
 		initEEnum(assignmentOperatorEEnum, AssignmentOperator.class, "AssignmentOperator");
 		addEEnumLiteral(assignmentOperatorEEnum, AssignmentOperator.STANDARD);

--- a/bundles/alpha.codegen/src/alpha/codegen/Factory.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/Factory.xtend
@@ -33,6 +33,11 @@ class Factory {
 	// Variables and Data Types
 	////////////////////////////////////////////////
 	
+	/** Creates a non-pointer data type. */
+	def static dataType(BaseDataType baseType) {
+		return dataType(baseType, 0)
+	}
+	
 	def static dataType(BaseDataType baseType, int indirectionLevel) {
 		val dataType = factory.createDataType
 		dataType.baseType = baseType

--- a/bundles/alpha.codegen/src/alpha/codegen/ProgramPrinter.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/ProgramPrinter.xtend
@@ -85,6 +85,7 @@ class ProgramPrinter {
 			case INT: '''int'''
 			case LONG: '''long'''
 			case FLOAT: '''float'''
+			case DOUBLE: '''double'''
 			default: fault
 		}
 	}

--- a/bundles/alpha.codegen/src/alpha/codegen/ProgramPrinter.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/ProgramPrinter.xtend
@@ -82,6 +82,7 @@ class ProgramPrinter {
 		return switch type {
 			case VOID: '''void'''
 			case CHAR: '''char'''
+			case INT: '''int'''
 			case LONG: '''long'''
 			case FLOAT: '''float'''
 			default: fault

--- a/bundles/alpha.codegen/src/alpha/codegen/writeC/Common.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/writeC/Common.xtend
@@ -65,21 +65,6 @@ class Common {
 		return dataType(BaseDataType.CHAR, 1)
 	}
 	
-	/** The data type for a value within an Alpha variable. */
-	def static alphaValueType() {
-		return dataType(BaseDataType.FLOAT, 0)
-	}
-	
-	/** The data type for a linearized Alpha variable. */
-	def static alphaVariableType() {
-		return alphaVariableType(1)
-	}
-	
-	/** The data type for an Alpha variable itself. */
-	def static alphaVariableType(int dimensionality) {
-		return dataType(BaseDataType.FLOAT, dimensionality)
-	}
-	
 	/** The data type for an index within Alpha. */
 	def static alphaIndexType() {
 		return dataType(BaseDataType.LONG, 0)

--- a/bundles/alpha.codegen/src/alpha/codegen/writeC/DependenceExprConverter.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/writeC/DependenceExprConverter.xtend
@@ -18,14 +18,22 @@ import alpha.model.VariableExpression
  * class, but were split out to improve readability. 
  */
 class DependenceExprConverter {
+	/** The converter used for converting the body of a dependence expression into C expressions. */
+	protected val ExprConverter exprConverter
+	
+	/** Constructs a new converter for dependence expressions. */
+	new(ExprConverter exprConverter) {
+		this.exprConverter = exprConverter
+	}
+	
 	/** Dispatches the conversion of a dependence expression based on the child expression. */
-	def static Expression convertExpr(ProgramBuilder program, DependenceExpression expr) {
+	def Expression convertExpr(ProgramBuilder program, DependenceExpression expr) {
 		return convertExpr(program, expr, expr.expr)
 	}
 	
 	/** If the child is a constant, then simply emit that constant. */
-	def static dispatch convertExpr(ProgramBuilder program, DependenceExpression parent, ConstantExpression child) {
-		ExprConverter.convertExpr(program, child)
+	def dispatch convertExpr(ProgramBuilder program, DependenceExpression parent, ConstantExpression child) {
+		exprConverter.convertExpr(program, child)
 	}
 	
 	/**
@@ -33,7 +41,7 @@ class DependenceExprConverter {
 	 * If the Alpha variable is an input, it's accessed via the memory macro.
 	 * Otherwise, it's accessed via the "eval" function.
 	 */
-	def static dispatch convertExpr(ProgramBuilder program, DependenceExpression parent, VariableExpression child) {
+	def dispatch convertExpr(ProgramBuilder program, DependenceExpression parent, VariableExpression child) {
 		// Build an expression for each index of the variable,
 		// as determined by each output dimension of the dependence function.
 		val indexExprs = AffineConverter.convertMultiAff(parent.function)
@@ -50,7 +58,7 @@ class DependenceExprConverter {
 	}
 	
 	/** Default case for child expressions that aren't supported yet. */
-	def static dispatch convertExpr(ProgramBuilder program, DependenceExpression parent, AlphaExpression child) {
+	def dispatch convertExpr(ProgramBuilder program, DependenceExpression parent, AlphaExpression child) {
 		throw new Exception("Not implemented yet!")
 	}
 }

--- a/bundles/alpha.codegen/src/alpha/codegen/writeC/SystemConverter.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/writeC/SystemConverter.xtend
@@ -84,6 +84,15 @@ class SystemConverter {
 	/**
 	 * Converts an Alpha system to the simplified C AST.
 	 * Only supports systems with a single body.
+	 * Defaults to data being of type "float".
+	 */
+	def static convert(AlphaSystem system, boolean oldAlphaZCompatible) {
+		return convert(system, BaseDataType.FLOAT, false)
+	}
+	
+	/**
+	 * Converts an Alpha system to the simplified C AST.
+	 * Only supports systems with a single body.
 	 * 
 	 * If requested, the code produced will aim for compatibility with
 	 * the older version of AlphaZ (although with no guarantees).

--- a/bundles/alpha.codegen/src/alpha/codegen/writeC/SystemConverter.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/writeC/SystemConverter.xtend
@@ -55,21 +55,30 @@ class SystemConverter {
 	/** A name checker to ensure names are unique. */
 	protected val WriteCNameChecker nameChecker
 	
+	/** The data type of values in the Alpha variables. */
+	protected val BaseDataType valueType
+	
+	/** The converter to use for turning Alpha expressions into C code. */
+	protected val ExprConverter exprConverter
+	
 	/** Protected constructor. */
-	protected new(AlphaSystem system, boolean oldAlphaZCompatible) {
+	protected new(AlphaSystem system, BaseDataType valueType, boolean oldAlphaZCompatible) {
 		this.allocatedVariables = newArrayList
 		this.oldAlphaZCompatible = oldAlphaZCompatible
 		this.system = system
 		this.nameChecker = new WriteCNameChecker
 		this.program = ProgramBuilder.start(this.nameChecker)
+		this.valueType = valueType
+		this.exprConverter = new ExprConverter(valueType)
 	}
 	
 	/**
 	 * Converts an Alpha system to the simplified C AST.
 	 * Only supports systems with a single body.
+	 * Defaults to data being of type "float" and linearizing memory usage.
 	 */
 	def static convert(AlphaSystem system) {
-		return convert(system, false)
+		return convert(system, BaseDataType.FLOAT, false)
 	}
 	
 	/**
@@ -86,14 +95,14 @@ class SystemConverter {
 	 * all indices are assumed to be of type "long",
 	 * and all data values are of type "float".
 	 */
-	def static convert(AlphaSystem system, boolean oldAlphaZCompatible) {
+	def static convert(AlphaSystem system, BaseDataType valueType, boolean oldAlphaZCompatible) {
 		// Duplicate the system and then preprocess the duplicate
 		// by applying normalization and name standardization.
 		val duplicate = system.copyAE
 		Normalize.apply(duplicate)
 		StandardizeNames.apply(duplicate)
 		
-		return (new SystemConverter(duplicate, oldAlphaZCompatible)).convertSystem
+		return (new SystemConverter(duplicate, valueType, oldAlphaZCompatible)).convertSystem
 	}
 	
 	/**
@@ -152,6 +161,23 @@ class SystemConverter {
 	
 	
 	/////////////////////////////////////////////////////////////////////////////
+	// Typing
+	/////////////////////////////////////////////////////////////////////////////
+	
+	def alphaValueType() {
+		return alphaVariableType(0)
+	}
+	
+	def alphaVariableType() {
+		return alphaVariableType(1)
+	}
+	
+	def alphaVariableType(int indirectionLevel) {
+		return Factory.dataType(valueType, indirectionLevel)
+	}
+	
+	
+	/////////////////////////////////////////////////////////////////////////////
 	// Variable and Memory Macro Declarations
 	/////////////////////////////////////////////////////////////////////////////
 	
@@ -181,7 +207,7 @@ class SystemConverter {
 	 */
 	def protected addLinearizedGlobalVariable(Variable variable) {
 		// Name checking is handled by the program builder.
-		program.addGlobalVariable(true, Common.alphaVariableType, variable.name)
+		program.addGlobalVariable(true, alphaVariableType, variable.name)
 		addLinearMemoryMacro(variable.name, variable.domain)
 	}
 	
@@ -197,7 +223,7 @@ class SystemConverter {
 		
 		// Create the global variable.
 		// Name checking is handled by the program builder.
-		val dataType = Common.alphaVariableType(variable.domain.nbIndices)
+		val dataType = alphaVariableType(variable.domain.nbIndices)
 		program.addGlobalVariable(true, dataType, variable.name)
 		
 		// Construct a memory macro for accessing the variable.
@@ -213,7 +239,7 @@ class SystemConverter {
 	 */
 	def protected addCompatiblityGlobalScalar(Variable variable) {
 		// The older AlphaZ system would pass in the variable as a pointer, just to a single value.
-		val dataType = Common.alphaVariableType(1)
+		val dataType = alphaVariableType(1)
 		program.addGlobalVariable(true, dataType, variable.name)
 		
 		val arrayAccess = Factory.arrayAccessExpr(variable.name, "0")
@@ -261,7 +287,7 @@ class SystemConverter {
 	 * at some point in its domain, returning the computed (or fetched) value.
 	 */
 	def protected createEvalFunction(StandardEquation equation) {
-		val evalBuilder = FunctionBuilder.start(Common.alphaValueType, equation.variable.evalName, nameChecker)
+		val evalBuilder = FunctionBuilder.start(alphaValueType, equation.variable.evalName, nameChecker)
 		
 		// Add a function parameter for each index of the variable's domain.
 		val indexNames = equation.expr.contextDomain.indexNames
@@ -285,7 +311,7 @@ class SystemConverter {
 	def protected getFlagCheckingBlock(StandardEquation equation) {
 		// For readability of this code, here is the statement that actually assigns
 		// the variable being computed.
-		val computeValue = ExprConverter.convertExpr(program, equation.expr)
+		val computeValue = exprConverter.convertExpr(program, equation.expr)
 		val computeAndStore = Factory.assignmentStmt(equation.identityAccess(false), computeValue)
 		
 		// If the flags indicate the value hasn't been evaluated yet:
@@ -361,7 +387,7 @@ class SystemConverter {
 		// However, if we need compatibility with the older AlphaZ system,
 		// change the level of indirection to match the number of indices
 		// in the variable's domain (minimum of 1, as scalars are still passed in as pointers).
-		val dataType = Common.alphaVariableType
+		val dataType = alphaVariableType
 		if (oldAlphaZCompatible) {
 			dataType.indirectionLevel = Integer.max(1, variable.domain.nbIndices)
 		}
@@ -432,7 +458,7 @@ class SystemConverter {
 		// Determine the name and data type of the C variable based on
 		// whether we're allocating memory for the standard variable or the flags variable.
 		val name = allocateFlag ? nameChecker.getFlagName(variable) : variable.name
-		val dataType = allocateFlag ? Common.flagVariableType : Common.alphaVariableType
+		val dataType = allocateFlag ? Common.flagVariableType : alphaVariableType
 		
 		// Record that we're allocating this variable so it can be freed later.
 		allocatedVariables.add(name)

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/Factory.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/Factory.java
@@ -39,6 +39,13 @@ public class Factory {
     return include;
   }
 
+  /**
+   * Creates a non-pointer data type.
+   */
+  public static DataType dataType(final BaseDataType baseType) {
+    return Factory.dataType(baseType, 0);
+  }
+
   public static DataType dataType(final BaseDataType baseType, final int indirectionLevel) {
     final DataType dataType = Factory.factory.createDataType();
     dataType.setBaseType(baseType);

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/ProgramPrinter.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/ProgramPrinter.java
@@ -173,6 +173,11 @@ public class ProgramPrinter {
           _builder_4.append("float");
           _switchResult = _builder_4.toString();
           break;
+        case DOUBLE:
+          StringConcatenation _builder_5 = new StringConcatenation();
+          _builder_5.append("double");
+          _switchResult = _builder_5.toString();
+          break;
         default:
           _switchResult = ProgramPrinter.fault();
           break;

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/ProgramPrinter.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/ProgramPrinter.java
@@ -158,15 +158,20 @@ public class ProgramPrinter {
           _builder_1.append("char");
           _switchResult = _builder_1.toString();
           break;
-        case LONG:
+        case INT:
           StringConcatenation _builder_2 = new StringConcatenation();
-          _builder_2.append("long");
+          _builder_2.append("int");
           _switchResult = _builder_2.toString();
           break;
-        case FLOAT:
+        case LONG:
           StringConcatenation _builder_3 = new StringConcatenation();
-          _builder_3.append("float");
+          _builder_3.append("long");
           _switchResult = _builder_3.toString();
+          break;
+        case FLOAT:
+          StringConcatenation _builder_4 = new StringConcatenation();
+          _builder_4.append("float");
+          _switchResult = _builder_4.toString();
           break;
         default:
           _switchResult = ProgramPrinter.fault();

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/Common.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/Common.java
@@ -69,27 +69,6 @@ public class Common {
   }
 
   /**
-   * The data type for a value within an Alpha variable.
-   */
-  public static DataType alphaValueType() {
-    return Factory.dataType(BaseDataType.FLOAT, 0);
-  }
-
-  /**
-   * The data type for a linearized Alpha variable.
-   */
-  public static DataType alphaVariableType() {
-    return Common.alphaVariableType(1);
-  }
-
-  /**
-   * The data type for an Alpha variable itself.
-   */
-  public static DataType alphaVariableType(final int dimensionality) {
-    return Factory.dataType(BaseDataType.FLOAT, dimensionality);
-  }
-
-  /**
    * The data type for an index within Alpha.
    */
   public static DataType alphaIndexType() {

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/DependenceExprConverter.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/DependenceExprConverter.java
@@ -25,17 +25,29 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 @SuppressWarnings("all")
 public class DependenceExprConverter {
   /**
+   * The converter used for converting the body of a dependence expression into C expressions.
+   */
+  protected final ExprConverter exprConverter;
+
+  /**
+   * Constructs a new converter for dependence expressions.
+   */
+  public DependenceExprConverter(final ExprConverter exprConverter) {
+    this.exprConverter = exprConverter;
+  }
+
+  /**
    * Dispatches the conversion of a dependence expression based on the child expression.
    */
-  public static Expression convertExpr(final ProgramBuilder program, final DependenceExpression expr) {
-    return DependenceExprConverter.convertExpr(program, expr, expr.getExpr());
+  public Expression convertExpr(final ProgramBuilder program, final DependenceExpression expr) {
+    return this.convertExpr(program, expr, expr.getExpr());
   }
 
   /**
    * If the child is a constant, then simply emit that constant.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final DependenceExpression parent, final ConstantExpression child) {
-    return ExprConverter.convertExpr(program, child);
+  protected Expression _convertExpr(final ProgramBuilder program, final DependenceExpression parent, final ConstantExpression child) {
+    return this.exprConverter.convertExpr(program, child);
   }
 
   /**
@@ -43,7 +55,7 @@ public class DependenceExprConverter {
    * If the Alpha variable is an input, it's accessed via the memory macro.
    * Otherwise, it's accessed via the "eval" function.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final DependenceExpression parent, final VariableExpression child) {
+  protected Expression _convertExpr(final ProgramBuilder program, final DependenceExpression parent, final VariableExpression child) {
     final ArrayList<CustomExpr> indexExprs = AffineConverter.convertMultiAff(parent.getFunction());
     Boolean _isInput = child.getVariable().isInput();
     if ((_isInput).booleanValue()) {
@@ -57,7 +69,7 @@ public class DependenceExprConverter {
   /**
    * Default case for child expressions that aren't supported yet.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final DependenceExpression parent, final AlphaExpression child) {
+  protected Expression _convertExpr(final ProgramBuilder program, final DependenceExpression parent, final AlphaExpression child) {
     try {
       throw new Exception("Not implemented yet!");
     } catch (Throwable _e) {
@@ -65,7 +77,7 @@ public class DependenceExprConverter {
     }
   }
 
-  public static Expression convertExpr(final ProgramBuilder program, final DependenceExpression parent, final AlphaExpression child) {
+  public Expression convertExpr(final ProgramBuilder program, final DependenceExpression parent, final AlphaExpression child) {
     if (child instanceof ConstantExpression) {
       return _convertExpr(program, parent, (ConstantExpression)child);
     } else if (child instanceof VariableExpression) {

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/ExprConverter.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/ExprConverter.java
@@ -1,5 +1,6 @@
 package alpha.codegen.writeC;
 
+import alpha.codegen.BaseDataType;
 import alpha.codegen.BinaryOperator;
 import alpha.codegen.CustomExpr;
 import alpha.codegen.Expression;
@@ -54,6 +55,32 @@ import org.eclipse.xtext.xbase.lib.ListExtensions;
  */
 @SuppressWarnings("all")
 public class ExprConverter {
+  /**
+   * The data type to use for Alpha values.
+   */
+  protected final BaseDataType alphaValueType;
+
+  /**
+   * The converter to use for reduce expressions.
+   */
+  protected final ReduceExprConverter reduceExprConverter;
+
+  /**
+   * The converter to use for dependence expressions.
+   */
+  protected final DependenceExprConverter dependenceExprConverter;
+
+  /**
+   * Constructs a new converter for reduce expressions.
+   */
+  public ExprConverter(final BaseDataType alphaValueType) {
+    this.alphaValueType = alphaValueType;
+    ReduceExprConverter _reduceExprConverter = new ReduceExprConverter(alphaValueType, this);
+    this.reduceExprConverter = _reduceExprConverter;
+    DependenceExprConverter _dependenceExprConverter = new DependenceExprConverter(this);
+    this.dependenceExprConverter = _dependenceExprConverter;
+  }
+
   protected static Expression externalNotSupported() {
     try {
       throw new Exception("Expressions that use external functions are not currently supported.");
@@ -62,23 +89,23 @@ public class ExprConverter {
     }
   }
 
-  protected static Expression _convertExpr(final ProgramBuilder program, final ExternalReduceExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final ExternalReduceExpression expr) {
     return ExprConverter.externalNotSupported();
   }
 
-  protected static Expression _convertExpr(final ProgramBuilder program, final ExternalArgReduceExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final ExternalArgReduceExpression expr) {
     return ExprConverter.externalNotSupported();
   }
 
-  protected static Expression _convertExpr(final ProgramBuilder program, final ExternalMultiArgExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final ExternalMultiArgExpression expr) {
     return ExprConverter.externalNotSupported();
   }
 
-  protected static Expression _convertExpr(final ProgramBuilder program, final ExternalFuzzyReduceExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final ExternalFuzzyReduceExpression expr) {
     return ExprConverter.externalNotSupported();
   }
 
-  protected static Expression _convertExpr(final ProgramBuilder program, final ExternalFuzzyArgReduceExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final ExternalFuzzyArgReduceExpression expr) {
     return ExprConverter.externalNotSupported();
   }
 
@@ -88,8 +115,8 @@ public class ExprConverter {
    * For restrict expressions inside "case" or "reduce" expressions,
    * the conditional checking should be handled by the conversion of the "case" or "reduce.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final RestrictExpression re) {
-    return ExprConverter.convertExpr(program, re.getExpr());
+  protected Expression _convertExpr(final ProgramBuilder program, final RestrictExpression re) {
+    return this.convertExpr(program, re.getExpr());
   }
 
   /**
@@ -98,14 +125,14 @@ public class ExprConverter {
    * For auto-restrict expressions inside "case" or "reduce" expressions,
    * the conditional checking should be handled by the conversion of the "case" or "reduce.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final AutoRestrictExpression re) {
-    return ExprConverter.convertExpr(program, re.getExpr());
+  protected Expression _convertExpr(final ProgramBuilder program, final AutoRestrictExpression re) {
+    return this.convertExpr(program, re.getExpr());
   }
 
   /**
    * Converts an Alpha "case" expression into a C ternary expression.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final CaseExpression ce) {
+  protected Expression _convertExpr(final ProgramBuilder program, final CaseExpression ce) {
     int _size = ce.getExprs().size();
     boolean _lessEqualsThan = (_size <= 0);
     if (_lessEqualsThan) {
@@ -120,7 +147,7 @@ public class ExprConverter {
     int _size_2 = ce.getExprs().size();
     boolean _equals = (_size_2 == 1);
     if (_equals) {
-      return ExprConverter.convertExpr(program, ce.getExprs().get(0));
+      return this.convertExpr(program, ce.getExprs().get(0));
     }
     AlphaExpression _xifexpression = null;
     int _size_3 = autoRestricts.size();
@@ -136,12 +163,12 @@ public class ExprConverter {
     };
     final Iterable<AlphaExpression> remainingCases = IterableExtensions.<AlphaExpression>reject(ce.getExprs(), _function);
     final AlphaExpression firstCase = IterableExtensions.<AlphaExpression>head(remainingCases);
-    final TernaryExprBuilder builder = TernaryExprBuilder.start(ExprConverter.createConditional(firstCase), ExprConverter.convertExpr(program, firstCase));
+    final TernaryExprBuilder builder = TernaryExprBuilder.start(ExprConverter.createConditional(firstCase), this.convertExpr(program, firstCase));
     final Consumer<AlphaExpression> _function_1 = (AlphaExpression it) -> {
-      builder.addCase(ExprConverter.createConditional(it), ExprConverter.convertExpr(program, it));
+      builder.addCase(ExprConverter.createConditional(it), this.convertExpr(program, it));
     };
     IterableExtensions.<AlphaExpression>tail(remainingCases).forEach(_function_1);
-    return builder.elseCase(ExprConverter.convertExpr(program, lastCase));
+    return builder.elseCase(this.convertExpr(program, lastCase));
   }
 
   /**
@@ -162,14 +189,14 @@ public class ExprConverter {
   /**
    * Dependence expression conversion is handled by a separate class.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final DependenceExpression expr) {
-    return DependenceExprConverter.convertExpr(program, expr);
+  protected Expression _convertExpr(final ProgramBuilder program, final DependenceExpression expr) {
+    return this.dependenceExprConverter.convertExpr(program, expr);
   }
 
-  protected static Expression _convertExpr(final ProgramBuilder program, final IfExpression expr) {
-    final Expression conditional = ExprConverter.convertExpr(program, expr.getCondExpr());
-    final Expression thenExpr = ExprConverter.convertExpr(program, expr.getThenExpr());
-    final Expression elseExpr = ExprConverter.convertExpr(program, expr.getElseExpr());
+  protected Expression _convertExpr(final ProgramBuilder program, final IfExpression expr) {
+    final Expression conditional = this.convertExpr(program, expr.getCondExpr());
+    final Expression thenExpr = this.convertExpr(program, expr.getThenExpr());
+    final Expression elseExpr = this.convertExpr(program, expr.getElseExpr());
     return Factory.ternaryExpr(conditional, thenExpr, elseExpr);
   }
 
@@ -177,20 +204,20 @@ public class ExprConverter {
    * Index expressions in Alpha convert indices into values.
    * Thus, we just need to output the expression itself.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final IndexExpression ie) {
+  protected Expression _convertExpr(final ProgramBuilder program, final IndexExpression ie) {
     final String exprLiteral = ISLAff._toString(ie.getFunction().getAff(0), ISL_FORMAT.C.ordinal());
     return Factory.customExpr(exprLiteral);
   }
 
-  protected static Expression _convertExpr(final ProgramBuilder program, final PolynomialIndexExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final PolynomialIndexExpression expr) {
     return PolynomialConverter.convert(expr.getPolynomial());
   }
 
   /**
    * Reduce expression conversion is handled by a separate class.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final ReduceExpression expr) {
-    return ReduceExprConverter.convertExpr(program, expr);
+  protected Expression _convertExpr(final ProgramBuilder program, final ReduceExpression expr) {
+    return this.reduceExprConverter.convertExpr(program, expr);
   }
 
   /**
@@ -199,7 +226,7 @@ public class ExprConverter {
    * by the dependence expression converter, not here.
    * If this is reached, then the variable is implicitly being accessed by the identity function.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final VariableExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final VariableExpression expr) {
     final Function1<String, CustomExpr> _function = (String it) -> {
       return Factory.customExpr(it);
     };
@@ -216,22 +243,22 @@ public class ExprConverter {
   /**
    * Constants in Alpha simply map to the same constant in C.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final ConstantExpression ce) {
+  protected Expression _convertExpr(final ProgramBuilder program, final ConstantExpression ce) {
     return Factory.customExpr(ce.valueString());
   }
 
   /**
    * There is a 1-to-1 matching between Alpha and C unary expressions.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final UnaryExpression ue) {
+  protected Expression _convertExpr(final ProgramBuilder program, final UnaryExpression ue) {
     final UnaryOperator op = Common.getOperator(ue.getOperator());
-    final Expression expr = ExprConverter.convertExpr(program, ue.getExpr());
+    final Expression expr = this.convertExpr(program, ue.getExpr());
     return Factory.unaryExpr(op, expr);
   }
 
-  protected static Expression _convertExpr(final ProgramBuilder program, final BinaryExpression be) {
-    final Expression left = ExprConverter.convertExpr(program, be.getLeft());
-    final Expression right = ExprConverter.convertExpr(program, be.getRight());
+  protected Expression _convertExpr(final ProgramBuilder program, final BinaryExpression be) {
+    final Expression left = this.convertExpr(program, be.getLeft());
+    final Expression right = this.convertExpr(program, be.getRight());
     final BinaryOperator op = Common.getOperator(be.getOperator());
     return Factory.binaryExpr(op, left, right);
   }
@@ -239,10 +266,10 @@ public class ExprConverter {
   /**
    * Multi-arg expressions are converted into a tree of nested binary expressions.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final MultiArgExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final MultiArgExpression expr) {
     final BinaryOperator op = Common.getOperator(expr.getOperator());
     final Function1<AlphaExpression, Expression> _function = (AlphaExpression it) -> {
-      return ExprConverter.convertExpr(program, it);
+      return this.convertExpr(program, it);
     };
     final List<Expression> children = ListExtensions.<AlphaExpression, Expression>map(expr.getExprs(), _function);
     return Factory.binaryExprTree(op, ((Expression[])Conversions.unwrapArray(children, Expression.class)));
@@ -251,7 +278,7 @@ public class ExprConverter {
   /**
    * Default case to catch unknown expression types.
    */
-  protected static Expression _convertExpr(final ProgramBuilder program, final AlphaExpression expr) {
+  protected Expression _convertExpr(final ProgramBuilder program, final AlphaExpression expr) {
     try {
       throw new Exception("Not implemented yet!");
     } catch (Throwable _e) {
@@ -259,7 +286,7 @@ public class ExprConverter {
     }
   }
 
-  public static Expression convertExpr(final ProgramBuilder program, final AlphaExpression expr) {
+  public Expression convertExpr(final ProgramBuilder program, final AlphaExpression expr) {
     if (expr instanceof ExternalArgReduceExpression) {
       return _convertExpr(program, (ExternalArgReduceExpression)expr);
     } else if (expr instanceof ExternalFuzzyArgReduceExpression) {

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/SystemConverter.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/SystemConverter.java
@@ -130,6 +130,15 @@ public class SystemConverter {
   /**
    * Converts an Alpha system to the simplified C AST.
    * Only supports systems with a single body.
+   * Defaults to data being of type "float".
+   */
+  public static Program convert(final AlphaSystem system, final boolean oldAlphaZCompatible) {
+    return SystemConverter.convert(system, BaseDataType.FLOAT, false);
+  }
+
+  /**
+   * Converts an Alpha system to the simplified C AST.
+   * Only supports systems with a single body.
    * 
    * If requested, the code produced will aim for compatibility with
    * the older version of AlphaZ (although with no guarantees).

--- a/bundles/alpha.model/src/alpha/model/util/ShowLegacyAlpha.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/ShowLegacyAlpha.xtend
@@ -34,8 +34,18 @@ import fr.irisa.cairn.jnimap.isl.ISLSet
  *   - all package and external function declarations are removed 
  */
 class ShowLegacyAlpha {
+	static val defaultValueType = "float"
+	
+	static def print(AlphaRoot root) {
+		return print(root, defaultValueType)
+	}
+	
 	static def print(AlphaRoot root, String valueType) {
 		root.systems.join("\n", [s|print(s, valueType)])
+	}
+	
+	static def print(AlphaSystem system) {
+		return print(system, defaultValueType)
 	}
 	
 	static def print(AlphaSystem system, String valueType) {
@@ -46,6 +56,10 @@ class ShowLegacyAlpha {
 		val show = new ShowLegacyAlphaForSystem(system.systemBodies.get(0), valueType);
 		
 		show.doSwitch(system).toString()
+	}
+	
+	static def print(SystemBody systemBody){
+		print(systemBody, defaultValueType)
 	}
 	
 	static def print(SystemBody systemBody, String valueType) {

--- a/bundles/alpha.model/src/alpha/model/util/ShowLegacyAlpha.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/ShowLegacyAlpha.xtend
@@ -6,18 +6,17 @@ import alpha.model.AlphaSystem
 import alpha.model.AutoRestrictExpression
 import alpha.model.BinaryExpression
 import alpha.model.CaseExpression
+import alpha.model.ConvolutionExpression
+import alpha.model.DependenceExpression
+import alpha.model.JNIDomain
+import alpha.model.PolynomialIndexExpression
 import alpha.model.RestrictExpression
+import alpha.model.SelectExpression
 import alpha.model.SystemBody
 import alpha.model.UnaryExpression
 import alpha.model.UseEquation
 import alpha.model.Variable
-import alpha.model.PolynomialIndexExpression
-import alpha.model.SelectExpression
-import alpha.model.ConvolutionExpression
-import alpha.model.JNIDomain
-import fr.irisa.cairn.jnimap.isl.ISLMultiAff
 import fr.irisa.cairn.jnimap.isl.ISLSet
-import alpha.model.DependenceExpression
 
 /**
  * Prints the Alpha program in Show notation of the older syntax used in
@@ -35,24 +34,22 @@ import alpha.model.DependenceExpression
  *   - all package and external function declarations are removed 
  */
 class ShowLegacyAlpha {
-
-	
-	static def print(AlphaRoot root) {
-		root.systems.join("\n", [s|print(s)])
+	static def print(AlphaRoot root, String valueType) {
+		root.systems.join("\n", [s|print(s, valueType)])
 	}
 	
-	static def print(AlphaSystem system) {
+	static def print(AlphaSystem system, String valueType) {
 		if (system.systemBodies.size > 1) {
 			throw new IllegalArgumentException("[ShowLegacyAlpha] A system with multiple bodies are not supported.");
 		}
 		
-		val show = new ShowLegacyAlphaForSystem(system.systemBodies.get(0));
+		val show = new ShowLegacyAlphaForSystem(system.systemBodies.get(0), valueType);
 		
 		show.doSwitch(system).toString()
 	}
 	
-	static def print(SystemBody systemBody) {
-		val show = new ShowLegacyAlphaForSystem(systemBody);
+	static def print(SystemBody systemBody, String valueType) {
+		val show = new ShowLegacyAlphaForSystem(systemBody, valueType);
 		
 		show.doSwitch(systemBody.system).toString()
 	}
@@ -60,8 +57,12 @@ class ShowLegacyAlpha {
 	static class ShowLegacyAlphaForSystem extends Show {
 		protected SystemBody targetBody
 		
-		new(SystemBody targetBody) {
+		/** The data type to use for the Alpha variables. */
+		val String valueType
+		
+		new(SystemBody targetBody, String valueType) {
 		 	this.targetBody = targetBody
+		 	this.valueType = valueType
 		}
 		
 		override protected printDomain(ISLSet set) {
@@ -104,7 +105,7 @@ class ShowLegacyAlpha {
 		}
 		
 		override caseVariable(Variable v) {
-			'''float «v.name» «v.domain.printVariableDeclarationDomain»;'''
+			'''«valueType» «v.name» «v.domain.printVariableDeclarationDomain»;'''
 		}
 		
 		override caseUseEquation(UseEquation ue) {

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/ShowLegacyAlpha.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/ShowLegacyAlpha.java
@@ -254,11 +254,21 @@ public class ShowLegacyAlpha {
     }
   }
 
+  private static final String defaultValueType = "float";
+
+  public static String print(final AlphaRoot root) {
+    return ShowLegacyAlpha.print(root, ShowLegacyAlpha.defaultValueType);
+  }
+
   public static String print(final AlphaRoot root, final String valueType) {
     final Function1<AlphaSystem, CharSequence> _function = (AlphaSystem s) -> {
       return ShowLegacyAlpha.print(s, valueType);
     };
     return IterableExtensions.<AlphaSystem>join(root.getSystems(), "\n", _function);
+  }
+
+  public static String print(final AlphaSystem system) {
+    return ShowLegacyAlpha.print(system, ShowLegacyAlpha.defaultValueType);
   }
 
   public static String print(final AlphaSystem system, final String valueType) {
@@ -274,6 +284,10 @@ public class ShowLegacyAlpha {
       _xblockexpression = show.doSwitch(system).toString();
     }
     return _xblockexpression;
+  }
+
+  public static String print(final SystemBody systemBody) {
+    return ShowLegacyAlpha.print(systemBody, ShowLegacyAlpha.defaultValueType);
   }
 
   public static String print(final SystemBody systemBody, final String valueType) {

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/ShowLegacyAlpha.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/ShowLegacyAlpha.java
@@ -44,8 +44,14 @@ public class ShowLegacyAlpha {
   public static class ShowLegacyAlphaForSystem extends Show {
     protected SystemBody targetBody;
 
-    public ShowLegacyAlphaForSystem(final SystemBody targetBody) {
+    /**
+     * The data type to use for the Alpha variables.
+     */
+    private final String valueType;
+
+    public ShowLegacyAlphaForSystem(final SystemBody targetBody, final String valueType) {
       this.targetBody = targetBody;
+      this.valueType = valueType;
     }
 
     @Override
@@ -163,7 +169,8 @@ public class ShowLegacyAlpha {
     @Override
     public CharSequence caseVariable(final Variable v) {
       StringConcatenation _builder = new StringConcatenation();
-      _builder.append("float ");
+      _builder.append(this.valueType);
+      _builder.append(" ");
       String _name = v.getName();
       _builder.append(_name);
       _builder.append(" ");
@@ -247,14 +254,14 @@ public class ShowLegacyAlpha {
     }
   }
 
-  public static String print(final AlphaRoot root) {
+  public static String print(final AlphaRoot root, final String valueType) {
     final Function1<AlphaSystem, CharSequence> _function = (AlphaSystem s) -> {
-      return ShowLegacyAlpha.print(s);
+      return ShowLegacyAlpha.print(s, valueType);
     };
     return IterableExtensions.<AlphaSystem>join(root.getSystems(), "\n", _function);
   }
 
-  public static String print(final AlphaSystem system) {
+  public static String print(final AlphaSystem system, final String valueType) {
     String _xblockexpression = null;
     {
       int _size = system.getSystemBodies().size();
@@ -263,16 +270,16 @@ public class ShowLegacyAlpha {
         throw new IllegalArgumentException("[ShowLegacyAlpha] A system with multiple bodies are not supported.");
       }
       SystemBody _get = system.getSystemBodies().get(0);
-      final ShowLegacyAlpha.ShowLegacyAlphaForSystem show = new ShowLegacyAlpha.ShowLegacyAlphaForSystem(_get);
+      final ShowLegacyAlpha.ShowLegacyAlphaForSystem show = new ShowLegacyAlpha.ShowLegacyAlphaForSystem(_get, valueType);
       _xblockexpression = show.doSwitch(system).toString();
     }
     return _xblockexpression;
   }
 
-  public static String print(final SystemBody systemBody) {
+  public static String print(final SystemBody systemBody, final String valueType) {
     String _xblockexpression = null;
     {
-      final ShowLegacyAlpha.ShowLegacyAlphaForSystem show = new ShowLegacyAlpha.ShowLegacyAlphaForSystem(systemBody);
+      final ShowLegacyAlpha.ShowLegacyAlphaForSystem show = new ShowLegacyAlpha.ShowLegacyAlphaForSystem(systemBody, valueType);
       _xblockexpression = show.doSwitch(systemBody.getSystem()).toString();
     }
     return _xblockexpression;

--- a/tests/alpha.codegen.tests/src/alpha/codegen/tests/writeC/SystemConverterManualTest.xtend
+++ b/tests/alpha.codegen.tests/src/alpha/codegen/tests/writeC/SystemConverterManualTest.xtend
@@ -5,6 +5,7 @@ import alpha.commands.Utility
 import alpha.codegen.writeC.SystemConverter
 import alpha.codegen.ProgramPrinter
 import java.io.FileWriter
+import alpha.codegen.BaseDataType
 
 /**
  * These are some manual tests which convert systems into C programs.
@@ -37,7 +38,7 @@ class SystemConverterManualTest {
 			val system = Utility.GetSystem(root, program)
 			
 			// Convert the system using older AlphaZ compatibility.
-			val cAST = SystemConverter.convert(system, true)
+			val cAST = SystemConverter.convert(system, BaseDataType.LONG, true)
 			val cProgram = ProgramPrinter.print(cAST).toString
 			
 			// Write the C program out.

--- a/tests/alpha.codegen.tests/xtend-gen/alpha/codegen/tests/writeC/SystemConverterManualTest.java
+++ b/tests/alpha.codegen.tests/xtend-gen/alpha/codegen/tests/writeC/SystemConverterManualTest.java
@@ -1,5 +1,6 @@
 package alpha.codegen.tests.writeC;
 
+import alpha.codegen.BaseDataType;
 import alpha.codegen.Program;
 import alpha.codegen.ProgramPrinter;
 import alpha.codegen.writeC.SystemConverter;
@@ -41,7 +42,7 @@ public class SystemConverterManualTest {
           final String alphaFile = (((("resources/" + program) + "/") + program) + ".alpha");
           final AlphaRoot root = AlphaLoader.loadAlpha(alphaFile);
           final AlphaSystem system = Utility.GetSystem(root, program);
-          final Program cAST = SystemConverter.convert(system, true);
+          final Program cAST = SystemConverter.convert(system, BaseDataType.LONG, true);
           final String cProgram = ProgramPrinter.print(cAST).toString();
           final String cFile = (((("resources/" + program) + "/") + program) + ".c");
           final FileWriter writer = new FileWriter(cFile);


### PR DESCRIPTION
Allows the code generator to treat values in AlphaZ as any data type. Intended to allow using an "int" or "long" for consistent verification of correctness.

Fixes #63 