### PR TITLE
Add hooks to optimal simplifying reductions

### DIFF
--- a/bundles/alpha.model/src-gen/alpha/model/matrix/impl/MatrixPackageImpl.java
+++ b/bundles/alpha.model/src-gen/alpha/model/matrix/impl/MatrixPackageImpl.java
@@ -88,6 +88,7 @@ public class MatrixPackageImpl extends EPackageImpl implements MatrixPackage {
 	private MatrixPackageImpl() {
 		super(eNS_URI, MatrixFactory.eINSTANCE);
 	}
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->


### PR DESCRIPTION
This modifies OptimalSimplifyingReductions. Now:
* splitting is turned off by default
* the target complexity can be specified

This is primarily to make invoking simplification from [acc](https://github.com/CSU-CS-Melange/alpha-codegen) easier. This is intended to be used with the changes in [alpha-codegen/pull/2](https://github.com/CSU-CS-Melange/alpha-codegen/pull/2).