### PR TITLE
Removing commas from a switch expression which caused incorrect results

### DIFF
--- a/bundles/alpha.codegen/src/alpha/codegen/writeC/Common.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/writeC/Common.xtend
@@ -172,14 +172,13 @@ class Common {
 	
 	/** Gets the expression for the maximum value of a data type. */
 	static def getMaxValue(BaseDataType dataType) {
-		val maxValue = switch dataType {
+		return switch dataType {
 			case INT: "INT_MAX"
 			case LONG: "LONG_MAX"
 			case FLOAT: "FLT_MAX"
 			case DOUBLE: "DBL_MAX"
 			default: throw new Exception("There is no maximum value for type '" + dataType + "'.")
-		}
-		return maxValue.customExpr
+		}.customExpr
 	}
 	
 	/** Gets the expression for the minimum value of a data type. */

--- a/bundles/alpha.codegen/src/alpha/codegen/writeC/Common.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/writeC/Common.xtend
@@ -171,22 +171,23 @@ class Common {
 	}
 	
 	/** Gets the expression for the maximum value of a data type. */
-	static def getMaxValue(BaseDataType dataType) {
-		return switch dataType {
-			case INT: "INT_MAX",
-			case LONG: "LONG_MAX",
-			case FLOAT: "FLT_MAX",
+	static def getMaxValue(BaseDataType ddataType) {
+		val maxValue = switch ddataType {
+			case INT: "INT_MAX"
+			case LONG: "LONG_MAX"
+			case FLOAT: "FLT_MAX"
 			case DOUBLE: "DBL_MAX"
-			default: throw new Exception("There is no maximum value for type '" + dataType + "'.")
-		}.customExpr
+			default: throw new Exception("There is no maximum value for type '" + ddataType + "'.")
+		}
+		return maxValue.customExpr
 	}
 	
 	/** Gets the expression for the minimum value of a data type. */
 	static def getMinValue(BaseDataType dataType) {
 		return switch dataType {
-			case INT: "INT_MIN",
-			case LONG: "LONG_MIN",
-			case FLOAT: "FLT_MIN",
+			case INT: "INT_MIN"
+			case LONG: "LONG_MIN"
+			case FLOAT: "FLT_MIN"
 			case DOUBLE: "DBL_MIN"
 			default: throw new Exception("There is no maximum value for type '" + dataType + "'.")
 		}.customExpr
@@ -195,9 +196,9 @@ class Common {
 	/** Gets the expression for 1 for the given data type. */
 	static def getOneValue(BaseDataType dataType) {
 		return switch dataType {
-			case INT: "1",
-			case LONG: "1L",
-			case FLOAT: "1.0f",
+			case INT: "1"
+			case LONG: "1L"
+			case FLOAT: "1.0f"
 			case DOUBLE: "1.0"
 			default: throw new Exception("There is no maximum value for type '" + dataType + "'.")
 		}.customExpr
@@ -206,9 +207,9 @@ class Common {
 	/** Gets the expression for 0 for the given data type. */
 	static def getZeroValue(BaseDataType dataType) {
 		return switch dataType {
-			case INT: "0",
-			case LONG: "0L",
-			case FLOAT: "0.0f",
+			case INT: "0"
+			case LONG: "0L"
+			case FLOAT: "0.0f"
 			case DOUBLE: "0.0"
 			default: throw new Exception("There is no maximum value for type '" + dataType + "'.")
 		}.customExpr

--- a/bundles/alpha.codegen/src/alpha/codegen/writeC/Common.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/writeC/Common.xtend
@@ -171,13 +171,13 @@ class Common {
 	}
 	
 	/** Gets the expression for the maximum value of a data type. */
-	static def getMaxValue(BaseDataType ddataType) {
-		val maxValue = switch ddataType {
+	static def getMaxValue(BaseDataType dataType) {
+		val maxValue = switch dataType {
 			case INT: "INT_MAX"
 			case LONG: "LONG_MAX"
 			case FLOAT: "FLT_MAX"
 			case DOUBLE: "DBL_MAX"
-			default: throw new Exception("There is no maximum value for type '" + ddataType + "'.")
+			default: throw new Exception("There is no maximum value for type '" + dataType + "'.")
 		}
 		return maxValue.customExpr
 	}

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/Common.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/Common.java
@@ -315,8 +315,7 @@ public class Common {
       } else {
         throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
       }
-      final String maxValue = _switchResult;
-      return Factory.customExpr(maxValue);
+      return Factory.customExpr(_switchResult);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/Common.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/Common.java
@@ -12,7 +12,6 @@ import alpha.model.BINARY_OP;
 import alpha.model.REDUCTION_OP;
 import alpha.model.UNARY_OP;
 import alpha.model.Variable;
-import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
@@ -293,51 +292,31 @@ public class Common {
   /**
    * Gets the expression for the maximum value of a data type.
    */
-  public static CustomExpr getMaxValue(final BaseDataType dataType) {
+  public static CustomExpr getMaxValue(final BaseDataType ddataType) {
     try {
       String _switchResult = null;
-      boolean _matched = false;
-      if (Objects.equal(dataType, BaseDataType.INT)) {
-        _matched=true;
-        _switchResult = "INT_MAX";
+      if (ddataType != null) {
+        switch (ddataType) {
+          case INT:
+            _switchResult = "INT_MAX";
+            break;
+          case LONG:
+            _switchResult = "LONG_MAX";
+            break;
+          case FLOAT:
+            _switchResult = "FLT_MAX";
+            break;
+          case DOUBLE:
+            _switchResult = "DBL_MAX";
+            break;
+          default:
+            throw new Exception((("There is no maximum value for type \'" + ddataType) + "\'."));
+        }
+      } else {
+        throw new Exception((("There is no maximum value for type \'" + ddataType) + "\'."));
       }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.LONG)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "LONG_MAX";
-        }
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.FLOAT)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "FLT_MAX";
-        }
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.DOUBLE)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "DBL_MAX";
-        }
-      }
-      if (!_matched) {
-        throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
-      }
-      return Factory.customExpr(_switchResult);
+      final String maxValue = _switchResult;
+      return Factory.customExpr(maxValue);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -349,45 +328,24 @@ public class Common {
   public static CustomExpr getMinValue(final BaseDataType dataType) {
     try {
       String _switchResult = null;
-      boolean _matched = false;
-      if (Objects.equal(dataType, BaseDataType.INT)) {
-        _matched=true;
-        _switchResult = "INT_MIN";
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.LONG)) {
-            _matched=true;
-          }
+      if (dataType != null) {
+        switch (dataType) {
+          case INT:
+            _switchResult = "INT_MIN";
+            break;
+          case LONG:
+            _switchResult = "LONG_MIN";
+            break;
+          case FLOAT:
+            _switchResult = "FLT_MIN";
+            break;
+          case DOUBLE:
+            _switchResult = "DBL_MIN";
+            break;
+          default:
+            throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
         }
-        if (_matched) {
-          _switchResult = "LONG_MIN";
-        }
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.FLOAT)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "FLT_MIN";
-        }
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.DOUBLE)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "DBL_MIN";
-        }
-      }
-      if (!_matched) {
+      } else {
         throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
       }
       return Factory.customExpr(_switchResult);
@@ -402,45 +360,24 @@ public class Common {
   public static CustomExpr getOneValue(final BaseDataType dataType) {
     try {
       String _switchResult = null;
-      boolean _matched = false;
-      if (Objects.equal(dataType, BaseDataType.INT)) {
-        _matched=true;
-        _switchResult = "1";
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.LONG)) {
-            _matched=true;
-          }
+      if (dataType != null) {
+        switch (dataType) {
+          case INT:
+            _switchResult = "1";
+            break;
+          case LONG:
+            _switchResult = "1L";
+            break;
+          case FLOAT:
+            _switchResult = "1.0f";
+            break;
+          case DOUBLE:
+            _switchResult = "1.0";
+            break;
+          default:
+            throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
         }
-        if (_matched) {
-          _switchResult = "1L";
-        }
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.FLOAT)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "1.0f";
-        }
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.DOUBLE)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "1.0";
-        }
-      }
-      if (!_matched) {
+      } else {
         throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
       }
       return Factory.customExpr(_switchResult);
@@ -455,45 +392,24 @@ public class Common {
   public static CustomExpr getZeroValue(final BaseDataType dataType) {
     try {
       String _switchResult = null;
-      boolean _matched = false;
-      if (Objects.equal(dataType, BaseDataType.INT)) {
-        _matched=true;
-        _switchResult = "0";
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.LONG)) {
-            _matched=true;
-          }
+      if (dataType != null) {
+        switch (dataType) {
+          case INT:
+            _switchResult = "0";
+            break;
+          case LONG:
+            _switchResult = "0L";
+            break;
+          case FLOAT:
+            _switchResult = "0.0f";
+            break;
+          case DOUBLE:
+            _switchResult = "0.0";
+            break;
+          default:
+            throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
         }
-        if (_matched) {
-          _switchResult = "0L";
-        }
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.FLOAT)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "0.0f";
-        }
-      }
-      if (!_matched) {
-        _matched=true;
-        if (!_matched) {
-          if (Objects.equal(dataType, BaseDataType.DOUBLE)) {
-            _matched=true;
-          }
-        }
-        if (_matched) {
-          _switchResult = "0.0";
-        }
-      }
-      if (!_matched) {
+      } else {
         throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
       }
       return Factory.customExpr(_switchResult);

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/Common.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/writeC/Common.java
@@ -292,11 +292,11 @@ public class Common {
   /**
    * Gets the expression for the maximum value of a data type.
    */
-  public static CustomExpr getMaxValue(final BaseDataType ddataType) {
+  public static CustomExpr getMaxValue(final BaseDataType dataType) {
     try {
       String _switchResult = null;
-      if (ddataType != null) {
-        switch (ddataType) {
+      if (dataType != null) {
+        switch (dataType) {
           case INT:
             _switchResult = "INT_MAX";
             break;
@@ -310,10 +310,10 @@ public class Common {
             _switchResult = "DBL_MAX";
             break;
           default:
-            throw new Exception((("There is no maximum value for type \'" + ddataType) + "\'."));
+            throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
         }
       } else {
-        throw new Exception((("There is no maximum value for type \'" + ddataType) + "\'."));
+        throw new Exception((("There is no maximum value for type \'" + dataType) + "\'."));
       }
       final String maxValue = _switchResult;
       return Factory.customExpr(maxValue);


### PR DESCRIPTION
Incorrect results were being returned because of commas at the end of "case" expressions within a "switch" expression block. Xtend uses commas to indicate fall through, which was causing the wrong result to be returned.

See: https://eclipse.dev/Xtext/xtend/documentation/203_xtend_expressions.html#fall-through

Fixes #69 