### PR TITLE
Raise Dependence: Only Factorize the Linear Terms

### DIFF
--- a/bundles/alpha.model/src/alpha/model/util/AffineFactorizer.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AffineFactorizer.xtend
@@ -211,6 +211,7 @@ class AffineFactorizer {
 		return expression
 	}
 	
+	// Creates a map from the given parameters and inputs to the empty set.
 	def private static mapToEmptySet(Collection<String> paramNames, Collection<String> inputNames) {
 		return '''[«paramNames.join(",")»] -> { [«inputNames.join(",")»] -> [] }'''.toString.toISLMultiAff
 	}

--- a/bundles/alpha.model/src/alpha/model/util/AffineFactorizer.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AffineFactorizer.xtend
@@ -297,27 +297,23 @@ class AffineFactorizer {
 	 * equal to the desired amount.
 	 */
 	def private static createDecompositionSpaces(ISLSpace originalSpace, int innerDimensionCount) {
-		// Get the names of the indexes for the inner dimension.
-		// Note: we need at least one inner dimension, otherwise we'll get null values.
-//		val namesToMake = (innerDimensionCount > 0) ? innerDimensionCount : 1
-		val namesToMake = innerDimensionCount
-		val innerNames = getNameGenerator("mid").take(namesToMake).toList
-		
 		// The first space we need has the same parameters and inputs as the original
 		// space, and one output per inner dimension (instead of the original outputs).
+		val outputNames = AlphaUtil.defaultDimNames(innerDimensionCount)
 		val ISLSpace firstSpace =
 			originalSpace
 			.copy
 			.dropDims(ISLDimType.isl_dim_out, 0, originalSpace.nbOutputs)
-			.addOutputs(innerNames)
+			.addOutputs(outputNames)
 		
 		// The second space we need has the same parameters and outputs as the original
 		// space, and one input per inner dimension (instead of the original inputs).
+		val inputNames = AlphaUtil.defaultDimNames(innerDimensionCount)
 		val ISLSpace secondSpace =
 			originalSpace
 			.copy
 			.dropDims(ISLDimType.isl_dim_in, 0, originalSpace.nbInputs)
-			.addInputs(innerNames)
+			.addInputs(inputNames)
 			
 		return firstSpace -> secondSpace
 	}

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AffineFactorizer.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AffineFactorizer.java
@@ -22,7 +22,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.Functions.Function2;
 import org.eclipse.xtext.xbase.lib.IntegerRange;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.IteratorExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
 
@@ -290,10 +289,10 @@ public class AffineFactorizer {
    * equal to the desired amount.
    */
   private static Pair<ISLSpace, ISLSpace> createDecompositionSpaces(final ISLSpace originalSpace, final int innerDimensionCount) {
-    final int namesToMake = innerDimensionCount;
-    final List<String> innerNames = IteratorExtensions.<String>toList(IteratorExtensions.<String>take(AffineFactorizer.getNameGenerator("mid"), namesToMake));
-    final ISLSpace firstSpace = originalSpace.copy().dropDims(ISLDimType.isl_dim_out, 0, originalSpace.getNbOutputs()).<ISLSpace>addOutputs(innerNames);
-    final ISLSpace secondSpace = originalSpace.copy().dropDims(ISLDimType.isl_dim_in, 0, originalSpace.getNbInputs()).<ISLSpace>addInputs(innerNames);
+    final List<String> outputNames = AlphaUtil.defaultDimNames(innerDimensionCount);
+    final ISLSpace firstSpace = originalSpace.copy().dropDims(ISLDimType.isl_dim_out, 0, originalSpace.getNbOutputs()).<ISLSpace>addOutputs(outputNames);
+    final List<String> inputNames = AlphaUtil.defaultDimNames(innerDimensionCount);
+    final ISLSpace secondSpace = originalSpace.copy().dropDims(ISLDimType.isl_dim_in, 0, originalSpace.getNbInputs()).<ISLSpace>addInputs(inputNames);
     return Pair.<ISLSpace, ISLSpace>of(firstSpace, secondSpace);
   }
 

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AffineFactorizer.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AffineFactorizer.java
@@ -9,10 +9,12 @@ import fr.irisa.cairn.jnimap.isl.ISLLocalSpace;
 import fr.irisa.cairn.jnimap.isl.ISLMatrix;
 import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
 import fr.irisa.cairn.jnimap.isl.ISLSpace;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.ExclusiveRange;
@@ -151,15 +153,15 @@ public class AffineFactorizer {
 
   /**
    * Returns the number of empty columns in the given matrix.
-   * Assumes that the empty rows appear only on the right of the matrix.
+   * Assumes that the empty rows appear only on the top of the matrix.
    */
   private static int countEmptyCols(final ISLMatrix matrix) {
     final int cols = matrix.getNbCols();
     final Function1<Integer, Boolean> _function = (Integer col) -> {
       return Boolean.valueOf(AffineFactorizer.isColEmpty(matrix, (col).intValue()));
     };
-    final int emptyRowCount = IterableExtensions.size(IterableExtensions.<Integer>takeWhile(new ExclusiveRange(cols, 1, false), _function));
-    return emptyRowCount;
+    final int emptyColCount = IterableExtensions.size(IterableExtensions.<Integer>takeWhile(new ExclusiveRange(cols, 0, false), _function));
+    return emptyColCount;
   }
 
   /**
@@ -179,6 +181,11 @@ public class AffineFactorizer {
    * Converts a matrix into an expression. Each column is for one of the output dimensions.
    */
   public static ISLMultiAff toExpression(final ISLMatrix matrix, final ISLSpace space) {
+    int _nbOutputs = space.getNbOutputs();
+    boolean _equals = (_nbOutputs == 0);
+    if (_equals) {
+      return AffineFactorizer.mapToEmptySet(space.getParamNames(), space.getInputNames());
+    }
     final List<String> paramNames = space.getParamNames();
     final List<String> inputNames = space.getInputNames();
     int _nbRows = matrix.getNbRows();
@@ -203,6 +210,18 @@ public class AffineFactorizer {
     return expression;
   }
 
+  private static ISLMultiAff mapToEmptySet(final Collection<String> paramNames, final Collection<String> inputNames) {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[");
+    String _join = IterableExtensions.join(paramNames, ",");
+    _builder.append(_join);
+    _builder.append("] -> { [");
+    String _join_1 = IterableExtensions.join(inputNames, ",");
+    _builder.append(_join_1);
+    _builder.append("] -> [] }");
+    return ISLUtil.toISLMultiAff(_builder.toString());
+  }
+
   /**
    * Decomposes an expression using the Hermite decomposition of the matrix
    * which represents the given expression. The decomposition is returned as
@@ -217,10 +236,23 @@ public class AffineFactorizer {
       ISLMultiAff _emptyExpr = AffineFactorizer.emptyExpr(expression.getContext());
       return Pair.<ISLMultiAff, ISLMultiAff>of(expression, _emptyExpr);
     }
-    final Pair<ISLMatrix, ISLMatrix> decomposed = AffineFactorizer.hermiteMatrixDecomposition(AffineFactorizer.expressionToMatrix(expression));
-    final ISLMatrix hMatrix = decomposed.getKey();
-    final ISLMatrix qMatrix = decomposed.getValue();
-    final Pair<ISLSpace, ISLSpace> spaces = AffineFactorizer.createDecompositionSpaces(expression.getSpace(), hMatrix.getNbCols());
+    final ISLMatrix fullMatrix = AffineFactorizer.expressionToMatrix(expression);
+    ISLMatrix _copy = fullMatrix.copy();
+    int _nbParams = expression.getNbParams();
+    int _nbInputs = expression.getNbInputs();
+    int _plus = (_nbInputs + 1);
+    final ISLMatrix paramsRows = _copy.dropRows(_nbParams, _plus);
+    final ISLMatrix indexRows = fullMatrix.copy().dropRows(0, expression.getNbParams()).dropRows(expression.getNbInputs(), 1);
+    int _nbParams_1 = expression.getNbParams();
+    int _nbInputs_1 = expression.getNbInputs();
+    int _plus_1 = (_nbParams_1 + _nbInputs_1);
+    final ISLMatrix constantsRow = fullMatrix.dropRows(0, _plus_1);
+    final Pair<ISLMatrix, ISLMatrix> decomposed = AffineFactorizer.hermiteMatrixDecomposition(indexRows);
+    final int hCols = decomposed.getKey().getNbCols();
+    final ISLMatrix hMatrix = AffineFactorizer.zeroMatrix(expression.getNbParams(), hCols).concat(decomposed.getKey()).concat(AffineFactorizer.zeroMatrix(1, hCols));
+    final ISLMatrix qMatrix = paramsRows.concat(decomposed.getValue()).concat(constantsRow);
+    final ISLSpace originalSpace = expression.getSpace();
+    final Pair<ISLSpace, ISLSpace> spaces = AffineFactorizer.createDecompositionSpaces(originalSpace, hMatrix.getNbCols());
     final ISLSpace hSpace = spaces.getKey();
     final ISLSpace qSpace = spaces.getValue();
     final ISLMultiAff hExpression = AffineFactorizer.toExpression(hMatrix, hSpace);
@@ -236,6 +268,21 @@ public class AffineFactorizer {
   }
 
   /**
+   * Returns a matrix of all zeros.
+   */
+  private static ISLMatrix zeroMatrix(final int rows, final int cols) {
+    ISLMatrix matrix = ISLMatrix.build(ISLContext.getInstance(), rows, cols);
+    ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, rows, true);
+    for (final Integer r : _doubleDotLessThan) {
+      ExclusiveRange _doubleDotLessThan_1 = new ExclusiveRange(0, cols, true);
+      for (final Integer c : _doubleDotLessThan_1) {
+        matrix = matrix.setElement((r).intValue(), (c).intValue(), 0);
+      }
+    }
+    return matrix;
+  }
+
+  /**
    * Creates the new spaces for the decomposition of the original space,
    * returned as a key->value pair. The key has the same domain as the
    * original space, and the value has the same range as the original space.
@@ -243,17 +290,10 @@ public class AffineFactorizer {
    * equal to the desired amount.
    */
   private static Pair<ISLSpace, ISLSpace> createDecompositionSpaces(final ISLSpace originalSpace, final int innerDimensionCount) {
-    int _xifexpression = (int) 0;
-    if ((innerDimensionCount > 0)) {
-      _xifexpression = innerDimensionCount;
-    } else {
-      _xifexpression = 1;
-    }
-    final int namesToMake = _xifexpression;
+    final int namesToMake = innerDimensionCount;
     final List<String> innerNames = IteratorExtensions.<String>toList(IteratorExtensions.<String>take(AffineFactorizer.getNameGenerator("mid"), namesToMake));
-    final ISLSpace firstSpace = originalSpace.copy().domain().reverse().<ISLSpace>addOutputs(innerNames);
-    final int paramCount = originalSpace.getNbParams();
-    final ISLSpace secondSpace = originalSpace.copy().range().dropDims(ISLDimType.isl_dim_param, 0, paramCount).<ISLSpace>addInputs(innerNames);
+    final ISLSpace firstSpace = originalSpace.copy().dropDims(ISLDimType.isl_dim_out, 0, originalSpace.getNbOutputs()).<ISLSpace>addOutputs(innerNames);
+    final ISLSpace secondSpace = originalSpace.copy().dropDims(ISLDimType.isl_dim_in, 0, originalSpace.getNbInputs()).<ISLSpace>addInputs(innerNames);
     return Pair.<ISLSpace, ISLSpace>of(firstSpace, secondSpace);
   }
 

--- a/tests/alpha.model.tests/src/alpha/model/tests/util/AffineFactorizerTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/util/AffineFactorizerTest.xtend
@@ -431,7 +431,7 @@ class AffineFactorizerTest {
 		val qActual = decomposed.value
 		
 		val hExpected = stringToMultiAff("[N] -> { [i,j,k] -> [i,j,k] }")
-		val qExpected = stringToMultiAff("{ [i,j,k] -> [i,j,k] }")
+		val qExpected = stringToMultiAff("[N] -> { [i,j,k] -> [i,j,k] }")
 		
 		assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual))
 		assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual))
@@ -446,7 +446,7 @@ class AffineFactorizerTest {
 		val qActual = decomposed.value
 		
 		val hExpected = stringToMultiAff("[N] -> { [i,j,k] -> [i+k,j] }")
-		val qExpected = stringToMultiAff("{ [x,y] -> [x,x+y] }")
+		val qExpected = stringToMultiAff("[N] -> { [x,y] -> [x,x+y] }")
 		
 		assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual))
 		assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual))
@@ -461,7 +461,7 @@ class AffineFactorizerTest {
 		val qActual = decomposed.value
 		
 		val hExpected = stringToMultiAff("[N] -> { [i,j,k] -> [i+k,j] }")
-		val qExpected = stringToMultiAff("{ [x,y] -> [x,x+y,x] }")
+		val qExpected = stringToMultiAff("[N] -> { [x,y] -> [x,x+y,x] }")
 		
 		assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual))
 		assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual))
@@ -475,8 +475,24 @@ class AffineFactorizerTest {
 		val hActual = decomposed.key
 		val qActual = decomposed.value
 		
-		val hExpected = stringToMultiAff("[N] -> { [i,j,k] -> [0] }")
-		val qExpected = stringToMultiAff("{ [i] -> [i,0,0,0] }")
+		// H will always at least output a constant 0.
+		val hExpected = stringToMultiAff("[N] -> { [i,j,k] -> [] }")
+		val qExpected = stringToMultiAff("[N] -> { [] -> [0,0,0,0] }")
+		
+		assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual))
+		assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual))
+	}
+	
+	@Test
+	def hermiteExpressionDecomposition_05() {
+		// Testing that we only factorize the linear part.
+		val original = stringToMultiAff("[N] -> { [i,j,k] -> [N, N+3, 7] }")
+		val decomposed = AffineFactorizer.hermiteExpressionDecomposition(original)
+		val hActual = decomposed.key
+		val qActual = decomposed.value
+		
+		val hExpected = stringToMultiAff("[N] -> { [i,j,k] -> [] }")
+		val qExpected = stringToMultiAff("[N] -> { [] -> [N,N+3,7] }")
 		
 		assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual))
 		assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual))
@@ -567,17 +583,20 @@ class AffineFactorizerTest {
 	
 	@Test
 	def factorizeExpressions_03() {
-		val expectedInnerDimensions = 5
+		// The common factor will only be for the linear part,
+		// so we expect it to pull out (i,j,k->i,j,k).
+		// Thus, there should only be 3 inner dimensions.
+		val expectedInnerDimensions = 3
 		assertFactorizationIsCorrect(expectedInnerDimensions,
 			"[N] -> { [i,j,k] -> [k,j,i,N,4] }")
 	}
 	
 	@Test
 	def factorizeExpressions_04() {
-		// The inner dimensions roughly map to i, j, k, and N,
-		// but they also have +/- constants in there so we don't
-		// need to directly express them.
-		val expectedInnerDimensions = 4
+		// The common factor will only be for the linear part,
+		// so we expect it to pull out (i,j,k->i,j,k).
+		// Thus, there should only be 3 inner dimensions.
+		val expectedInnerDimensions = 3
 		assertFactorizationIsCorrect(expectedInnerDimensions,
 			"[N] -> { [i,j,k] -> [i+j, N+k] }",
 			"[N] -> { [i,j,k] -> [j+k, N+j+3] }")
@@ -585,8 +604,10 @@ class AffineFactorizerTest {
 	
 	@Test
 	def factorizeExpressions_05() {
-		// The inner dimensions are: N+4, M, i+k, j
-		val expectedInnerDimensions = 4
+		// The common factor will only be for the linear part,
+		// so we expect it to pull out (i,j,k->i+k,j) or similar.
+		// Thus, there should only be 2 inner dimensions.
+		val expectedInnerDimensions = 2
 		assertFactorizationIsCorrect(expectedInnerDimensions,
 			"[N,M] -> { [i,j,k] -> [i+k, N-j+4] }",
 			"[N,M] -> { [i,j,k] -> [M+N+4, N+M+4] }",

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/util/AffineFactorizerTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/util/AffineFactorizerTest.java
@@ -300,7 +300,7 @@ public class AffineFactorizerTest {
     final ISLMultiAff hActual = decomposed.getKey();
     final ISLMultiAff qActual = decomposed.getValue();
     final ISLMultiAff hExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [i,j,k] -> [i,j,k] }");
-    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("{ [i,j,k] -> [i,j,k] }");
+    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [i,j,k] -> [i,j,k] }");
     Assert.assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual));
     Assert.assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual));
   }
@@ -312,7 +312,7 @@ public class AffineFactorizerTest {
     final ISLMultiAff hActual = decomposed.getKey();
     final ISLMultiAff qActual = decomposed.getValue();
     final ISLMultiAff hExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [i,j,k] -> [i+k,j] }");
-    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("{ [x,y] -> [x,x+y] }");
+    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [x,y] -> [x,x+y] }");
     Assert.assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual));
     Assert.assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual));
   }
@@ -324,7 +324,7 @@ public class AffineFactorizerTest {
     final ISLMultiAff hActual = decomposed.getKey();
     final ISLMultiAff qActual = decomposed.getValue();
     final ISLMultiAff hExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [i,j,k] -> [i+k,j] }");
-    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("{ [x,y] -> [x,x+y,x] }");
+    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [x,y] -> [x,x+y,x] }");
     Assert.assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual));
     Assert.assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual));
   }
@@ -335,8 +335,20 @@ public class AffineFactorizerTest {
     final Pair<ISLMultiAff, ISLMultiAff> decomposed = AffineFactorizer.hermiteExpressionDecomposition(original);
     final ISLMultiAff hActual = decomposed.getKey();
     final ISLMultiAff qActual = decomposed.getValue();
-    final ISLMultiAff hExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [i,j,k] -> [0] }");
-    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("{ [i] -> [i,0,0,0] }");
+    final ISLMultiAff hExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [i,j,k] -> [] }");
+    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [] -> [0,0,0,0] }");
+    Assert.assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual));
+    Assert.assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual));
+  }
+
+  @Test
+  public void hermiteExpressionDecomposition_05() {
+    final ISLMultiAff original = AffineFactorizerTest.stringToMultiAff("[N] -> { [i,j,k] -> [N, N+3, 7] }");
+    final Pair<ISLMultiAff, ISLMultiAff> decomposed = AffineFactorizer.hermiteExpressionDecomposition(original);
+    final ISLMultiAff hActual = decomposed.getKey();
+    final ISLMultiAff qActual = decomposed.getValue();
+    final ISLMultiAff hExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [i,j,k] -> [] }");
+    final ISLMultiAff qExpected = AffineFactorizerTest.stringToMultiAff("[N] -> { [] -> [N,N+3,7] }");
     Assert.assertTrue("The decomposed H is incorrect.", hExpected.isPlainEqual(hActual));
     Assert.assertTrue("The decomposed Q is incorrect.", qExpected.isPlainEqual(qActual));
   }
@@ -411,14 +423,14 @@ public class AffineFactorizerTest {
 
   @Test
   public void factorizeExpressions_03() {
-    final int expectedInnerDimensions = 5;
+    final int expectedInnerDimensions = 3;
     AffineFactorizerTest.assertFactorizationIsCorrect(expectedInnerDimensions, 
       "[N] -> { [i,j,k] -> [k,j,i,N,4] }");
   }
 
   @Test
   public void factorizeExpressions_04() {
-    final int expectedInnerDimensions = 4;
+    final int expectedInnerDimensions = 3;
     AffineFactorizerTest.assertFactorizationIsCorrect(expectedInnerDimensions, 
       "[N] -> { [i,j,k] -> [i+j, N+k] }", 
       "[N] -> { [i,j,k] -> [j+k, N+j+3] }");
@@ -426,7 +438,7 @@ public class AffineFactorizerTest {
 
   @Test
   public void factorizeExpressions_05() {
-    final int expectedInnerDimensions = 4;
+    final int expectedInnerDimensions = 2;
     AffineFactorizerTest.assertFactorizationIsCorrect(expectedInnerDimensions, 
       "[N,M] -> { [i,j,k] -> [i+k, N-j+4] }", 
       "[N,M] -> { [i,j,k] -> [M+N+4, N+M+4] }", 


### PR DESCRIPTION
Only factorize the linear terms so that if you factorize the following:

```
(i,j -> i+3)
(i,j -> i+N)
```

You end up with the following as the common factor:

```
(i,j -> i)
```

Instead of the following, which has more dimensions than necessary:

```
(i,j -> N-3, i+3)
```