### PR TITLE
Fix macro parenthesization in codegen

### DIFF
--- a/bundles/alpha.codegen/src/alpha/codegen/isl/AffineConverter.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/isl/AffineConverter.xtend
@@ -23,7 +23,10 @@ class AffineConverter {
 	
 	/** Converts a single affine expression to a single C expression. */
 	def static convertAff(ISLAff aff) {
-		val literal = aff.toString(ISL_FORMAT.C)
+		val literal = aff.inputNames.fold(
+			aff.toString(ISL_FORMAT.C),
+			[ret, index | ret.replace(index, '(' + index + ')')]
+		)
 		return Factory.customExpr("(" + literal + ")")
 	}
 }

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/isl/AffineConverter.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/isl/AffineConverter.java
@@ -8,6 +8,8 @@ import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
 import fr.irisa.cairn.jnimap.isl.ISL_FORMAT;
 import java.util.ArrayList;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.Functions.Function2;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 
 /**
@@ -32,7 +34,11 @@ public class AffineConverter {
    * Converts a single affine expression to a single C expression.
    */
   public static CustomExpr convertAff(final ISLAff aff) {
-    final String literal = aff.toString(ISL_FORMAT.C);
+    final Function2<String, String, String> _function = (String ret, String index) -> {
+      return ret.replace(index, (("(" + index) + ")"));
+    };
+    final String literal = IterableExtensions.<String, String>fold(aff.getInputNames(), 
+      aff.toString(ISL_FORMAT.C), _function);
     return Factory.customExpr((("(" + literal) + ")"));
   }
 }


### PR DESCRIPTION
Fixes an issue related to the way the macros behave in the generated code.

Before this change, the code generator could produce the following:
```
…
#define S_C2_NR_0(tt,ti,p,w) C2_NR(tt,ti,p) += (allW((w))) * (Y((3*tt - w),(9*ti + p + w)))
...
        for (int c2 = -2; c2 < 0; c2 += 1) {
          for (int c4 = 1; c4 < (N + 2) / 9 - 1; c4 += 1) {
            S_C2_NR_0(c0 + 1, c4, c2, 3 * c0 - c1 + 3);
          }
        }
...
```
This is bad because the 4th argument is improperly expanded in the expression for `3*tt - w`. It becomes `3*tt - 3 * c0 - c1 + 3` when it should be `3*tt - 3 * c0 + c1 - 3`. We haven’t noticed this because most of the macro definitions appearing in demand driven codegen only involve identity expressions.

After this change, the code generator properly parenthesizes all macro definitions. It generates the following for the above example:
```
#define S_C2_NR_0(tt,ti,p,w) C2_NR(tt,ti,p) += (allW(((w)))) * (Y((3*(tt) - (w)),(9*(ti) + (p) + (w))))
```