### PR TITLE
GitHub hosted actions v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,3 +100,10 @@ jobs:
         cc-test-reporter format-coverage -t jacoco "${JACOCO_PREFIX}/coverage/cc-${GITHUB_SHA}.xml" --output "codeclimate.json"
         cc-test-reporter upload-coverage --input "codeclimate.json"
 
+    - name: save the plugin as an artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: plugin-artifact
+        path: |
+          ./releng/alpha.language.update/target/repository/
+          ./scripts/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     container: ghcr.io/csu-cs-melange/alpha-language-image:latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: prepare code coverage instrumentation
       run: cc-test-reporter before-build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,12 +28,10 @@ jobs:
     container: ghcr.io/csu-cs-melange/alpha-language-image:latest
 
     steps:
-    - name: Cache alpha language plugin
-      id: cache-plugin
-      uses: actions/cache@v3
+    - name: Load the build artifacts
+      uses: actions/download-artifact@v4
       with:
-        path: ./releng/alpha.language.update/target/repository
-        key: cache-plugin
+        name: plugin-artifact   # Must match the name from the build action.
 
     - name: Set SHORT_SHA 
       run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV


### PR DESCRIPTION
Changing the use of the "cache" action in the "deploy" job, as it did not work correctly. It's being replaced with uploading an artifact in "build", then downloading that in "deploy". See the link below for details on how these work.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow

Per the link below, artifacts are intended for passing files from one job to another within the same workflow instance, while caches are intended to pass files between workflow instances.

https://echobind.com/post/difference-between-artifacts-and-cache-in-GitHub-Actions