### PR TITLE
Fixing file permissions in the deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Make downloads directory
       run: mkdir -p ./releng/alpha.language.update/target/repository/downloads
 
+    - name: fix permissions
+      run: chmod +x ./scripts/make-update-site-readme.sh
+
     - name: make update-site readme
       run: ./scripts/make-update-site-readme.sh
  
@@ -56,6 +59,3 @@ jobs:
     - name: deploy update-site
       id: deployment
       uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action
-
-
-


### PR DESCRIPTION
Turns out, uploaded artifacts will not retain their permissions. This caused an issue in the deploy step, which ran a script that was saved this way. To fix this, I added a step that makes the script executable.