### PR TITLE
ACC fix for duplicate macro indices

### DIFF
--- a/bundles/alpha.codegen/src/alpha/codegen/demandDriven/WriteC.xtend
+++ b/bundles/alpha.codegen/src/alpha/codegen/demandDriven/WriteC.xtend
@@ -336,7 +336,12 @@ class WriteC extends CodeGeneratorBase {
 	override preprocess() {
 		Normalize.apply(systemBody)
 		NormalizeReduction.apply(systemBody)
-		StandardizeNames.apply(systemBody)
+		/*
+		 * Demand driven codegen incorrectly produces macros with duplicate names, see #103
+		 * The issue is caused by StandardizeNames, commenting out fixes the issue.
+		 */
+
+//		StandardizeNames.apply(systemBody)
 	}
 	
 }

--- a/bundles/alpha.codegen/xtend-gen/alpha/codegen/demandDriven/WriteC.java
+++ b/bundles/alpha.codegen/xtend-gen/alpha/codegen/demandDriven/WriteC.java
@@ -36,7 +36,6 @@ import alpha.model.SystemBody;
 import alpha.model.UseEquation;
 import alpha.model.Variable;
 import alpha.model.transformation.Normalize;
-import alpha.model.transformation.StandardizeNames;
 import alpha.model.transformation.reduction.NormalizeReduction;
 import alpha.model.util.AlphaUtil;
 import alpha.model.util.CommonExtensions;
@@ -366,6 +365,5 @@ public class WriteC extends CodeGeneratorBase {
   public void preprocess() {
     Normalize.apply(this.systemBody);
     NormalizeReduction.apply(this.systemBody);
-    StandardizeNames.apply(this.systemBody);
   }
 }


### PR DESCRIPTION
Repeat of #116. Closes #103 