### PR TITLE
Serialize reduction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
         alpha.model.tests.scheduling.PRDGTest
         alpha.model.tests.transformation.reduction.NormalizeReductionDeepTest
         alpha.model.tests.transformation.reduction.SplitReductionTest
+        alpha.model.tests.transformation.reduction.SerializeReductionTest
         alpha.model.tests.transformations.DistributivityTest
         alpha.model.tests.transformations.FactorOutFromReductionTest
         alpha.model.tests.transformations.HigherOrderOperatorTest

--- a/bundles/alpha.model/src/alpha/model/transformation/reduction/SerializeReduction.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/reduction/SerializeReduction.xtend
@@ -1,0 +1,188 @@
+package alpha.model.transformation.reduction
+
+import alpha.model.AbstractReduceExpression
+import alpha.model.AlphaExpression
+import alpha.model.AlphaInternalStateConstructor
+import alpha.model.AlphaSystem
+import alpha.model.CaseExpression
+import alpha.model.RestrictExpression
+import alpha.model.StandardEquation
+import alpha.model.Variable
+import alpha.model.factory.AlphaUserFactory
+import alpha.model.util.AlphaOperatorUtil
+import alpha.model.util.AlphaUtil
+import static extension alpha.model.util.ISLUtil.*
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet
+import fr.irisa.cairn.jnimap.isl.ISLMap
+import fr.irisa.cairn.jnimap.isl.ISLMultiAff
+import fr.irisa.cairn.jnimap.isl.ISLPoint
+import fr.irisa.cairn.jnimap.isl.ISLSet
+import org.eclipse.emf.ecore.util.EcoreUtil
+
+/**
+ * Serializes a reduction along given reuse function(s).
+ * This class is not given enough information to automatically decompose
+ * reductions, so it must serialize all dimensions of the reduction at once.
+ * Users can manually apply DecomposeReduction beforehand if they only wish to
+ * partially serialize the reduction.
+ * 
+ */
+class SerializeReduction { //TODO: allow partial serialization
+	static def void apply(AbstractReduceExpression reduce, ISLMultiAff reuseDep) {
+		val Variable writeVar = (AlphaUtil.getContainerEquation(reduce) as StandardEquation).variable
+		val String newName = AlphaUtil.duplicateNameResolver.apply(
+			AlphaUtil.getContainerSystem(reduce),
+			writeVar.name + "_reduction",
+			"_"
+		)
+		apply(reduce, reuseDep, newName)
+	}
+	
+	static def void apply(AbstractReduceExpression reduce, ISLMultiAff reuseDep, String newName) {
+		checkArguments(reduce, #[reuseDep], newName)
+		serialize(reduce, reuseDep, newName)
+	}
+	
+	static def void applyAll(AbstractReduceExpression reduce, Iterable<ISLMultiAff> partialReuseDeps) {
+		checkArguments(reduce, partialReuseDeps, "")
+		
+		//extend reuseDeps to span the whole nullspace if it isn't long enough.
+		var reuseDeps = partialReuseDeps.map[a | a]
+		var nullSpace = reduce.projectionExpr.getISLMultiAff.copy.nullSpace
+		if(reuseDeps.size <  nullSpace.copy.dimensionality) {
+			val Iterable<ISLPoint> reuseVectors = reuseDeps.map[dep | dep.copy.toMap.deltas.samplePoint]
+			
+			for(var i = 0; i < reuseVectors.size; i++) {
+				nullSpace = nullSpace.apply(reuseVectors.get(i).copy.buildRejectionMaff.toMap)
+			}
+			
+			reuseDeps = reuseDeps + nullSpace.getBasisVectors.map[vec | vec.buildTranslationMaff]
+		}
+		
+		val Variable writeVar = (AlphaUtil.getContainerEquation(reduce) as StandardEquation).variable
+		
+		for(var i = 0; i < reuseDeps.length-1; i++)  {
+			val String newName = AlphaUtil.duplicateNameResolver.apply(
+				AlphaUtil.getContainerSystem(reduce),
+				writeVar.name + "_reduction",
+				i.toString
+			)
+			val writeMaff = reduce.projectionExpr.getISLMultiAff
+			
+			val reuseDep = reuseDeps.get(i)
+			val ISLMultiAff f1 = buildRejectionMaff(reuseDep.copy.toMap.deltas.samplePoint)
+			val ISLMultiAff f2 = writeMaff.copy.toMap.applyDomain(f1.copy.toMap).toMultiAff
+			
+			ReductionDecomposition.apply(reduce, f1, f2)
+			
+			serialize(reduce.body as AbstractReduceExpression, reuseDep, newName)
+		}
+		
+		val String newName = AlphaUtil.duplicateNameResolver.apply(
+			AlphaUtil.getContainerSystem(reduce),
+			writeVar.name + "_reduction",
+			(reuseDeps.length-1).toString
+		)
+			
+		serialize(reduce, reuseDeps.get(reuseDeps.length-1), newName)
+	}
+	
+	private static def void serialize(AbstractReduceExpression reduce, ISLMultiAff reuseDep, String newName) {
+		var AlphaSystem sys = AlphaUtil.getContainerSystem(reduce)		
+		val systemBody = AlphaUtil.getContainerSystemBody(reduce)
+		val ISLSet body = reduce.body.getContextDomain
+		val ISLMultiAff writeMaff = reduce.projectionExpr.getISLMultiAff
+		var AlphaExpression coreExpr = reduce.body 
+		if(coreExpr instanceof RestrictExpression) coreExpr = coreExpr.expr
+		
+		val Variable reductionVar = AlphaUserFactory.createVariable(newName, body.copy)
+		sys.locals.add(reductionVar)
+
+		val ISLSet top = body.copy.subtract(body.copy.apply(reuseDep.copy.toMap)).simplify
+		val ISLSet bottom = body.copy.subtract(body.copy.apply(reuseDep.copy.toMap.reverse)).simplify
+		
+		val CaseExpression writeCaseExpr = AlphaUserFactory.createCaseExpression()
+		
+		var ISLSet coveredDomain = ISLSet.buildEmpty(body.copy.apply(writeMaff.copy.toMap).getSpace)
+		for( ISLBasicSet basicFacet : top.getBasicSets ) {
+			val ISLSet facet = basicFacet.copy.toSet
+			val ISLMap shadowProject = writeMaff.copy.toMap.intersectDomain(facet.copy)
+			val ISLSet shadow = facet.copy.apply(shadowProject.copy).subtract(coveredDomain.copy)
+			coveredDomain = coveredDomain.union(shadow.copy)
+			
+			val readExpr = AlphaUserFactory.createVariableExpression(reductionVar)
+			
+			var AlphaExpression dependenceExpr
+			if(shadowProject.copy.reverse.isSingleValued) {
+				dependenceExpr = AlphaUserFactory.createDependenceExpression(
+					shadowProject.copy.reverse.toMultiAff,
+					readExpr
+				)
+			}
+			else {
+				dependenceExpr = AlphaUserFactory.createReduceExpression(
+					reduce.operator,
+					writeMaff.copy,
+					AlphaUserFactory.createRestrictExpression(
+						top.copy,
+						readExpr
+					)
+				)
+			}
+			
+			writeCaseExpr.exprs += AlphaUserFactory.createRestrictExpression(shadow, dependenceExpr)
+		}
+		
+		EcoreUtil.replace(reduce, writeCaseExpr)
+	
+		val readCaseExpr = AlphaUserFactory.createCaseExpression()
+		val selfDepExpr = AlphaUserFactory.createDependenceExpression(
+			reuseDep.copy, 
+			AlphaUserFactory.createVariableExpression(reductionVar)
+		)
+		 
+		readCaseExpr.exprs += AlphaUserFactory.createRestrictExpression(
+			bottom.copy, 
+			EcoreUtil.copy(coreExpr)
+		)
+		readCaseExpr.exprs += AlphaUserFactory.createRestrictExpression(
+			body.copy.subtract(bottom.copy), 
+			AlphaUserFactory.createBinaryExpression(
+				AlphaOperatorUtil.reductionOPtoBinaryOP(reduce.operator),
+				EcoreUtil.copy(coreExpr),
+				selfDepExpr
+			)
+		)
+		
+		val standardEq = AlphaUserFactory.createStandardEquation(reductionVar, readCaseExpr)
+		systemBody.equations += standardEq
+		
+		AlphaInternalStateConstructor.recomputeContextDomain(sys)
+	}
+	
+	static def private void checkArguments(AbstractReduceExpression reduce, Iterable<ISLMultiAff> reuseDeps, String newName) {
+		val ISLMultiAff writeMaff = reduce.projectionExpr.getISLMultiAff
+		val nullSpace = writeMaff.copy.nullSpace
+		
+		val Iterable<ISLPoint> reuseVectors = reuseDeps.map[dep | dep.copy.toMap.deltas.samplePoint]
+		if(!reuseVectors.forall[vector | vector.copy.toSet.isSubset(nullSpace.copy)]) {
+			throw new IllegalArgumentException("[SerializeReduction] Reuse dependences: " + reuseDeps +
+				"\ndo not all reside in the nullspace of the projection function: " + reduce	)
+		}
+		
+		val dimensionality = reuseVectors.getSpan.dimensionality
+		if(dimensionality < reuseVectors.size) {
+			throw new IllegalArgumentException("[SerializeReduction] Reuse dependences: " + reuseDeps +
+				"\ndo not form a linearly independent set.")
+		}
+		
+		var AlphaSystem sys = AlphaUtil.getContainerSystem(reduce)
+		if(sys === null) {
+			throw new IllegalArgumentException("[SerializeReduction] Reduction Expression has no containing system.")
+		}
+		
+		if(sys.getVariable(newName) !== null) {
+			throw new IllegalArgumentException("[SerializeReduction] Variable with name " + newName + " already exists in the system.")
+		}
+	}
+}

--- a/bundles/alpha.model/src/alpha/model/transformation/reduction/SerializeReduction.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/reduction/SerializeReduction.xtend
@@ -4,20 +4,26 @@ import alpha.model.AbstractReduceExpression
 import alpha.model.AlphaExpression
 import alpha.model.AlphaInternalStateConstructor
 import alpha.model.AlphaSystem
+import alpha.model.BINARY_OP
 import alpha.model.CaseExpression
 import alpha.model.RestrictExpression
 import alpha.model.StandardEquation
 import alpha.model.Variable
-import alpha.model.factory.AlphaUserFactory
 import alpha.model.util.AlphaOperatorUtil
 import alpha.model.util.AlphaUtil
-import static extension alpha.model.util.ISLUtil.*
+import alpha.model.util.FaceLattice
+import alpha.model.util.JavaUtil
 import fr.irisa.cairn.jnimap.isl.ISLBasicSet
 import fr.irisa.cairn.jnimap.isl.ISLMap
 import fr.irisa.cairn.jnimap.isl.ISLMultiAff
 import fr.irisa.cairn.jnimap.isl.ISLPoint
 import fr.irisa.cairn.jnimap.isl.ISLSet
+import java.util.ArrayList
 import org.eclipse.emf.ecore.util.EcoreUtil
+
+import static extension alpha.model.factory.AlphaUserFactory.*
+import static extension alpha.model.util.ISLUtil.*
+import fr.irisa.cairn.jnimap.isl.ISLDimType
 
 /**
  * Serializes a reduction along given reuse function(s).
@@ -49,7 +55,7 @@ class SerializeReduction {
 	 */
 	static def void applyAuto(AbstractReduceExpression are) {
 		var nullSpace = are.projectionExpr.getISLMultiAff.copy.nullSpace
-		SerializeReduction.applyAll(are, nullSpace.getBasisVectors.map[vec | vec.buildTranslationMaff])
+		SerializeReduction.applySequential(are, nullSpace.getBasisVectors.map[vec | vec.buildTranslationMaff])
 	}
 	
 	static def void apply(AbstractReduceExpression are, ISLMultiAff reuseDep, String newName) {
@@ -57,7 +63,12 @@ class SerializeReduction {
 		serialize(are, reuseDep, newName)
 	}
 	
-	static def void applyAll(AbstractReduceExpression are, Iterable<ISLMultiAff> partialReuseDeps) {
+	/**
+	 * Applies a series of reductions, creating a new temporary variable for each.
+	 * Avoids a potentially exponential number of domains, at the cost of
+	 * potential schedule bloat when fed to FoutrierScheduler
+	 */
+	static def void applySequential(AbstractReduceExpression are, Iterable<ISLMultiAff> partialReuseDeps) {
 		checkArguments(are, partialReuseDeps, "")
 		
 		//extend reuseDeps to span the whole nullspace if it isn't long enough.
@@ -102,6 +113,160 @@ class SerializeReduction {
 		serialize(are, reuseDeps.get(reuseDeps.length-1), newName)
 	}
 	
+	static def void applyOneShot(AbstractReduceExpression are, ISLMultiAff rho, String newName) {
+		//TODO argument checking
+		
+		serializeOneShot(are, rho, newName)
+	}
+	
+	/**
+	 * Serialize a reduction using only one accumulation vector
+	 * May have an exponential number of domains
+	 * But avoids schedule bloat from having more variables than needed
+	 */
+	private static def void serializeOneShot(AbstractReduceExpression are, ISLMultiAff rho, String newName) {
+		val ISLSet body = are.body.getContextDomain	
+		val ISLMultiAff writeMaff = are.projectionExpr.getISLMultiAff
+
+		var AlphaExpression coreExpr = are.body 
+		if(coreExpr instanceof RestrictExpression) coreExpr = coreExpr.expr
+		
+		var sys = AlphaUtil.getContainerSystem(are)
+		val Variable reductionVar = createVariable(newName, body.copy)
+		sys.locals.add(reductionVar)
+		
+		/*
+		 * The basin is the set of points whose flow along rho does not exit the reduction body
+		 * The top is the set of points which do flow outside the body
+		 */
+		val ISLSet basin = body.copy.intersect(body.copy.apply(rho.copy.toMap.reverse))
+		val ISLSet top = body.copy.subtract(basin.copy).simplify
+		val ISLSet bottom = body.copy.subtract(body.copy.apply(rho.copy.toMap)).simplify
+		
+		val FaceLattice lattice = FaceLattice.create(body.getBasicSetAt(0).copy)
+		
+		/*
+		 * We create a new set of vectors to flow along once information reaches the top
+		 * These vectors are defined by the vector along each edge that becomes rho
+		 * when projected onto it
+		 * So each edgeFlowVec is assigned the same timestamp as rho
+		 */
+		val ISLSet rhoProjPreimage = rho.copy.toMap.deltas.preimage(
+			rho.copy.toMap.deltas.samplePoint.buildProjectionMaff
+		)
+		//TODO: implemented wrong. Need to analyze the *slice* of the reduction body
+		val int nExtraDims = body.dim(ISLDimType.isl_dim_set) - writeMaff.copy.nullSpace.dimensionality
+		val Iterable<ISLPoint> edgeFlowVecs = lattice.getFaces(1 + nExtraDims).map[edge | edge.toBasicSet.toSet]
+			.filter[set | set.copy.isSubset(top.copy)]
+			.map[set | 
+				set.getBasisVectors.getSpan.intersect(
+					writeMaff.copy.nullSpace
+				).intersect(
+					rhoProjPreimage.copy
+				)
+			].filter[set | !set.isEmpty]
+			.map[set | set.samplePoint]
+
+		/*
+		 * A set of actually useful edge flow vectors is produced, along with the domains they accumulate.
+		 * The peak is the remaining set of unaccumulated points
+		 */
+		var ISLSet peak = top.copy
+		var infoFlowMaps = new ArrayList<ISLMap>
+		for(ISLPoint vec : edgeFlowVecs) {
+			val accumulatedPoints = top.copy.intersect(top.copy.apply(rho.copy.toMap.reverse))
+			
+			if(!accumulatedPoints.isEmpty) {
+				infoFlowMaps +=
+					vec.buildTranslationMaff.toMap.intersectDomain(accumulatedPoints.copy)
+				
+				peak = peak.subtract(accumulatedPoints)
+			}
+		}
+		infoFlowMaps += rho.copy.toMap.intersectDomain(basin)
+		
+		/*
+		 * Now convert the flow maps (flow vectors plus the domains they accumulate)
+		 * into actual dependences, and insert them into the program
+		 */
+		var CaseExpression cases = infoFlowToCases(
+			infoFlowMaps, 
+			AlphaOperatorUtil.reductionOPtoBinaryOP(are.operator),
+			reductionVar,
+			coreExpr
+		)
+		cases.exprs += createRestrictExpression(
+			bottom,
+			AlphaUtil.copyAE(coreExpr)
+		)
+		AlphaUtil.getContainerSystemBody(are).equations += createStandardEquation(
+			reductionVar, 
+			cases
+		)
+		/*
+		 * The peak (hopefully bounded, potentially not) is now accumulated with a reduction
+		 * into the write variable
+		 */
+		EcoreUtil.replace(
+			are,
+			createReduceExpression(
+				are.operator,
+				writeMaff,
+				createRestrictExpression(
+					peak,
+					createVariableExpression(reductionVar)
+				)
+			)
+		)
+		
+		AlphaInternalStateConstructor.recomputeContextDomain(sys)
+	}
+	
+	/**
+	 * Takes flow information (domains plus the Maff along which they accumulate)
+	 * and turns it into dependences
+	 * Because the ranges of flow maps can intersect, the number of domains one needs to consider
+	 * becomes exponential wrt. dimension
+	 * 
+	 * O(2^d) for realistic cases
+	 * O(2^(2^d)) worst case
+	 */
+	private static def CaseExpression infoFlowToCases(Iterable<ISLMap> infoFlowMaps, BINARY_OP op, Variable v, AlphaExpression coreExpr) {
+		val CaseExpression cases = createCaseExpression()
+		
+		JavaUtil.powerSet(infoFlowMaps.toSet).forEach[ wantMaps | 
+			val unwantMaps = infoFlowMaps.filter[map | !wantMaps.contains(map)]
+			
+			//Bottom of the reduction is handled separately
+			if(wantMaps.size < 1) return;
+			
+			var range = wantMaps.map[map | map.getRange]
+				.reduce[a, b | a.copy.intersect(b.copy)]
+			if(!unwantMaps.empty) range = range.subtract(
+					unwantMaps.map[map | map.getRange]
+					.reduce[a, b | a.copy.union(b.copy)]
+				)
+			if(range.isEmpty) return;
+			
+			//Generate cases for each combination of flow ranges
+			cases.exprs += createRestrictExpression(
+				range,
+				AlphaUtil.createNaryExpression(
+					op,
+					wantMaps.map[ map | 
+						createDependenceExpression(
+							map.copy.reverse.toMultiAff,
+							createVariableExpression(v)
+						)
+					] + #[AlphaUtil.copyAE(coreExpr)]
+				)
+			)
+		]
+		
+		return cases
+	}
+	
+	
 	/**
 	 * The main serialize method, which all public-facing methods eventually call.
 	 */
@@ -113,7 +278,7 @@ class SerializeReduction {
 		var AlphaExpression coreExpr = are.body 
 		if(coreExpr instanceof RestrictExpression) coreExpr = coreExpr.expr
 		
-		val Variable reductionVar = AlphaUserFactory.createVariable(newName, body.copy)
+		val Variable reductionVar = createVariable(newName, body.copy)
 		sys.locals.add(reductionVar)
 
 		/*
@@ -123,7 +288,7 @@ class SerializeReduction {
 		val ISLSet top = body.copy.subtract(body.copy.apply(reuseDep.copy.toMap)).simplify
 		val ISLSet bottom = body.copy.subtract(body.copy.apply(reuseDep.copy.toMap.reverse)).simplify
 		
-		val CaseExpression writeCaseExpr = AlphaUserFactory.createCaseExpression()
+		val CaseExpression writeCaseExpr = createCaseExpression()
 		/*
 		 * Create a dependence from the write variable to each top 'facet' of the serialized reduction.
 		 * Typically, there is only one such facet.
@@ -135,7 +300,7 @@ class SerializeReduction {
 			val ISLSet shadow = facet.copy.apply(shadowProject.copy).subtract(coveredDomain.copy)
 			coveredDomain = coveredDomain.union(shadow.copy)
 			
-			val readExpr = AlphaUserFactory.createVariableExpression(reductionVar)
+			val readExpr = createVariableExpression(reductionVar)
 			
 			/*
 			 * Replaces the ReduceExpression with a simple DependenceExpression if it is
@@ -144,23 +309,23 @@ class SerializeReduction {
 			 */
 			var AlphaExpression dependenceExpr
 			if(shadowProject.copy.reverse.isSingleValued) {
-				dependenceExpr = AlphaUserFactory.createDependenceExpression(
+				dependenceExpr = createDependenceExpression(
 					shadowProject.copy.reverse.toMultiAff,
 					readExpr
 				)
 			}
 			else {
-				dependenceExpr = AlphaUserFactory.createReduceExpression(
+				dependenceExpr = createReduceExpression(
 					are.operator,
 					writeMaff.copy,
-					AlphaUserFactory.createRestrictExpression(
+					createRestrictExpression(
 						top.copy,
 						readExpr
 					)
 				)
 			}
 			
-			writeCaseExpr.exprs += AlphaUserFactory.createRestrictExpression(shadow, dependenceExpr)
+			writeCaseExpr.exprs += createRestrictExpression(shadow, dependenceExpr)
 		}
 		
 		EcoreUtil.replace(are, writeCaseExpr)
@@ -168,10 +333,10 @@ class SerializeReduction {
 		/*
 		 * Generates the Exprs that the new StandardEquation will use.
 		 */
-		val readCaseExpr = AlphaUserFactory.createCaseExpression()
-		val selfDepExpr = AlphaUserFactory.createDependenceExpression(
+		val readCaseExpr = createCaseExpression()
+		val selfDepExpr = createDependenceExpression(
 			reuseDep.copy, 
-			AlphaUserFactory.createVariableExpression(reductionVar)
+			createVariableExpression(reductionVar)
 		)
 		
 		/*
@@ -179,20 +344,20 @@ class SerializeReduction {
 		 * The rest read from the read variable, and also their fellow points using
 		 * reuseDep as a uniform dependence.
 		 */
-		readCaseExpr.exprs += AlphaUserFactory.createRestrictExpression(
+		readCaseExpr.exprs += createRestrictExpression(
 			bottom.copy, 
 			EcoreUtil.copy(coreExpr)
 		)
-		readCaseExpr.exprs += AlphaUserFactory.createRestrictExpression(
+		readCaseExpr.exprs += createRestrictExpression(
 			body.copy.subtract(bottom.copy), 
-			AlphaUserFactory.createBinaryExpression(
+			createBinaryExpression(
 				AlphaOperatorUtil.reductionOPtoBinaryOP(are.operator),
 				EcoreUtil.copy(coreExpr),
 				selfDepExpr
 			)
 		)
 		
-		val standardEq = AlphaUserFactory.createStandardEquation(reductionVar, readCaseExpr)
+		val standardEq = createStandardEquation(reductionVar, readCaseExpr)
 		systemBody.equations += standardEq
 		
 		AlphaInternalStateConstructor.recomputeContextDomain(sys)

--- a/bundles/alpha.model/src/alpha/model/transformation/reduction/SerializeReduction.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/reduction/SerializeReduction.xtend
@@ -30,26 +30,28 @@ import fr.irisa.cairn.jnimap.isl.ISLDimType
  * 
  * This will modify the container system of the given ReduceExpression.
  * 
- * This class is not given enough information to automatically decompose
- * reductions, so it must serialize all dimensions of the reduction at once.
- * Users can manually apply DecomposeReduction beforehand if they only wish to
- * partially serialize the reduction.
+ * Three methods are included:
+ * - apply: serializes a reduction of rank 1 with a single accumulation vector.
+ * - applyAuto: serializes a reduction with automatically generated accumulation vectors.
+ * - applySequential: serializes a reduction of rank n with up to n accumulation vectors
+ * 		(more accumulation vectors are automatically generated as needed).
+ * - applyOneShot: serializes a reduction of any rank with a single accumulation vector.
  */
 class SerializeReduction {
 	/**
 	 * Applies a 1D serialization. Can only be used on reductions of rank 1.
 	 */
-	static def void apply(AbstractReduceExpression are, ISLMultiAff reuseDep) {
-		apply(are, reuseDep, generateReductionName(are))
+	static def void apply(AbstractReduceExpression are, ISLMultiAff accumulationMaff) {
+		apply(are, accumulationMaff, generateReductionName(are))
 	}
 	
-	static def void apply(AbstractReduceExpression are, ISLMultiAff reuseDep, String newName) {
-		checkArguments(are, #[reuseDep], newName, false)
-		serialize(are, reuseDep, newName)
+	static def void apply(AbstractReduceExpression are, ISLMultiAff accumulationMaff, String newName) {
+		checkArguments(are, #[accumulationMaff], newName, false)
+		serialize(are, accumulationMaff, newName)
 	}
 	
 	/**
-	 * Serializes a reduction using an arbitrary set of basis vectors as reuse dependences.
+	 * Serializes a reduction using an arbitrary set of basis vectors as directions of accumulation.
 	 * This is not guaranteed to be a 'good' serialization, but it will certainly be valid.
 	 */
 	static def void applyAuto(AbstractReduceExpression are) {
@@ -71,26 +73,26 @@ class SerializeReduction {
 	 * Avoids a potentially exponential number of domains, at the cost of
 	 * potential schedule bloat when fed to FoutrierScheduler
 	 */
-	static def void applySequential(AbstractReduceExpression are, Iterable<ISLMultiAff> partialReuseDeps) {
-		checkArguments(are, partialReuseDeps, "", false)
+	static def void applySequential(AbstractReduceExpression are, Iterable<ISLMultiAff> partialaccumulationMaffs) {
+		checkArguments(are, partialaccumulationMaffs, "", false)
 		
-		//extend reuseDeps to span the whole nullspace if it isn't long enough.
-		var reuseDeps = partialReuseDeps.map[a | a]
+		//extend accumulationMaffs to span the whole nullspace if it isn't long enough.
+		var accumulationMaffs = partialaccumulationMaffs.map[a | a]
 		var nullSpace = are.projectionExpr.getISLMultiAff.copy.nullSpace
-		if(reuseDeps.size <  nullSpace.copy.dimensionality) {
-			val Iterable<ISLPoint> reuseVectors = reuseDeps.map[dep | dep.copy.toMap.deltas.samplePoint]
+		if(accumulationMaffs.size <  nullSpace.copy.dimensionality) {
+			val Iterable<ISLPoint> accumulationVectors = accumulationMaffs.map[accumulationMaff | accumulationMaff.copy.toMap.deltas.samplePoint]
 			
-			for(var i = 0; i < reuseVectors.size; i++) {
-				nullSpace = nullSpace.apply(reuseVectors.get(i).copy.buildRejectionMaff.toMap)
+			for(var i = 0; i < accumulationVectors.size; i++) {
+				nullSpace = nullSpace.apply(accumulationVectors.get(i).copy.buildRejectionMaff.toMap)
 			}
 			
-			reuseDeps = reuseDeps + nullSpace.getBasisVectors.map[vec | vec.buildTranslationMaff]
+			accumulationMaffs = accumulationMaffs + nullSpace.getBasisVectors.map[vec | vec.buildTranslationMaff]
 		}
 		
 		val Variable writeVar = (AlphaUtil.getContainerEquation(are) as StandardEquation).variable
 		
 		//Serialize the reduction one dependence at a time.
-		for(var i = 0; i < reuseDeps.length-1; i++)  {
+		for(var i = 0; i < accumulationMaffs.length-1; i++)  {
 			val String newName = AlphaUtil.duplicateNameResolver.apply(
 				AlphaUtil.getContainerSystem(are),
 				writeVar.name + "_reduction",
@@ -98,31 +100,31 @@ class SerializeReduction {
 			)
 			val writeMaff = are.projectionExpr.getISLMultiAff
 			
-			val reuseDep = reuseDeps.get(i)
-			val ISLMultiAff f1 = buildRejectionMaff(reuseDep.copy.toMap.deltas.samplePoint)
+			val accumulationMaff = accumulationMaffs.get(i)
+			val ISLMultiAff f1 = buildRejectionMaff(accumulationMaff.copy.toMap.deltas.samplePoint)
 			val ISLMultiAff f2 = writeMaff.copy.toMap.applyDomain(f1.copy.toMap).toMultiAff
 			
 			ReductionDecomposition.apply(are, f1, f2)
 			
-			serialize(are.body as AbstractReduceExpression, reuseDep, newName)
+			serialize(are.body as AbstractReduceExpression, accumulationMaff, newName)
 		}
 		
 		val String newName = AlphaUtil.duplicateNameResolver.apply(
 			AlphaUtil.getContainerSystem(are),
 			writeVar.name + "_reduction",
-			(reuseDeps.length-1).toString
+			(accumulationMaffs.length-1).toString
 		)
 			
-		serialize(are, reuseDeps.get(reuseDeps.length-1), newName)
+		serialize(are, accumulationMaffs.get(accumulationMaffs.length-1), newName)
 	}
 	
-	static def void applyOneShot(AbstractReduceExpression are, ISLMultiAff rho) {
-		applyOneShot(are, rho, generateReductionName(are))
+	static def void applyOneShot(AbstractReduceExpression are, ISLMultiAff accumulationMaff) {
+		applyOneShot(are, accumulationMaff, generateReductionName(are))
 	}
 	
-	static def void applyOneShot(AbstractReduceExpression are, ISLMultiAff rho, String newName) {
-		checkArguments(are, #[rho], newName, false)
-		serializeOneShot(are, rho, newName)
+	static def void applyOneShot(AbstractReduceExpression are, ISLMultiAff accumulationMaff, String newName) {
+		checkArguments(are, #[accumulationMaff], newName, false)
+		serializeOneShot(are, accumulationMaff, newName)
 	}
 	
 	private static def String generateReductionName(AbstractReduceExpression are) {
@@ -139,7 +141,7 @@ class SerializeReduction {
 	 * May have an exponential number of domains
 	 * But avoids schedule bloat from having more variables than needed
 	 */
-	private static def void serializeOneShot(AbstractReduceExpression are, ISLMultiAff rho, String newName) {
+	private static def void serializeOneShot(AbstractReduceExpression are, ISLMultiAff accumulationMaff, String newName) {
 		val ISLSet body = are.body.getContextDomain	
 		val ISLMultiAff writeMaff = are.projectionExpr.getISLMultiAff
 
@@ -151,25 +153,24 @@ class SerializeReduction {
 		sys.locals.add(reductionVar)
 		
 		/*
-		 * The basin is the set of points whose flow along rho does not exit the reduction body
+		 * The basin is the set of points whose flow along accumulationMaff does not exit the reduction body
 		 * The top is the set of points which do flow outside the body
 		 */
-		val ISLSet basin = body.copy.intersect(body.copy.apply(rho.copy.toMap.reverse))
+		val ISLSet basin = body.copy.intersect(body.copy.apply(accumulationMaff.copy.toMap.reverse))
 		val ISLSet top = body.copy.subtract(basin.copy).simplify
-		val ISLSet bottom = body.copy.subtract(body.copy.apply(rho.copy.toMap)).simplify
+		val ISLSet bottom = body.copy.subtract(body.copy.apply(accumulationMaff.copy.toMap)).simplify
 		
 		val FaceLattice lattice = FaceLattice.create(body.getBasicSetAt(0).copy)
 		
 		/*
 		 * We create a new set of vectors to flow along once information reaches the top
-		 * These vectors are defined by the vector along each edge that becomes rho
+		 * These vectors are defined by the vector along each edge that becomes accumulationMaff
 		 * when projected onto it
-		 * So each edgeFlowVec is assigned the same timestamp as rho
+		 * So each edgeFlowVec is assigned the same timestamp as accumulationMaff
 		 */
-		val ISLSet rhoProjPreimage = rho.copy.toMap.deltas.preimage(
-			rho.copy.toMap.deltas.samplePoint.buildProjectionMaff
+		val ISLSet accumulationMaffProjPreimage = accumulationMaff.copy.toMap.deltas.preimage(
+			accumulationMaff.copy.toMap.deltas.samplePoint.buildProjectionMaff
 		)
-		//TODO: implemented wrong. Need to analyze the *slice* of the reduction body
 		val int nExtraDims = body.dim(ISLDimType.isl_dim_set) - writeMaff.copy.nullSpace.dimensionality
 		val Iterable<ISLPoint> edgeFlowVecs = lattice.getFaces(1 + nExtraDims).map[edge | edge.toBasicSet.toSet]
 			.filter[set | set.copy.isSubset(top.copy)]
@@ -177,7 +178,7 @@ class SerializeReduction {
 				set.getBasisVectors.getSpan.intersect(
 					writeMaff.copy.nullSpace
 				).intersect(
-					rhoProjPreimage.copy
+					accumulationMaffProjPreimage.copy
 				)
 			].filter[set | !set.isEmpty]
 			.map[set | set.samplePoint]
@@ -189,7 +190,7 @@ class SerializeReduction {
 		var ISLSet peak = top.copy
 		var infoFlowMaps = new ArrayList<ISLMap>
 		for(ISLPoint vec : edgeFlowVecs) {
-			val accumulatedPoints = top.copy.intersect(top.copy.apply(rho.copy.toMap.reverse))
+			val accumulatedPoints = top.copy.intersect(top.copy.apply(accumulationMaff.copy.toMap.reverse))
 			
 			if(!accumulatedPoints.isEmpty) {
 				infoFlowMaps +=
@@ -198,7 +199,7 @@ class SerializeReduction {
 				peak = peak.subtract(accumulatedPoints)
 			}
 		}
-		infoFlowMaps += rho.copy.toMap.intersectDomain(basin)
+		infoFlowMaps += accumulationMaff.copy.toMap.intersectDomain(basin)
 		
 		/*
 		 * Now convert the flow maps (flow vectors plus the domains they accumulate)
@@ -283,9 +284,9 @@ class SerializeReduction {
 	
 	
 	/**
-	 * The main serialize method, which all public-facing methods eventually call.
+	 * The main serialize method, which apply and applyAll eventually call.
 	 */
-	private static def void serialize(AbstractReduceExpression are, ISLMultiAff reuseDep, String newName) {
+	private static def void serialize(AbstractReduceExpression are, ISLMultiAff accumulationMaff, String newName) {
 		var AlphaSystem sys = AlphaUtil.getContainerSystem(are)		
 		val systemBody = AlphaUtil.getContainerSystemBody(are)
 		val ISLSet body = are.body.getContextDomain
@@ -300,8 +301,8 @@ class SerializeReduction {
 		 * The 'top' set of points are what is read by the write variable.
 		 * The 'bottom' set of points do not read any other points in the serialized reduction.
 		 */
-		val ISLSet top = body.copy.subtract(body.copy.apply(reuseDep.copy.toMap)).simplify
-		val ISLSet bottom = body.copy.subtract(body.copy.apply(reuseDep.copy.toMap.reverse)).simplify
+		val ISLSet top = body.copy.subtract(body.copy.apply(accumulationMaff.copy.toMap)).simplify
+		val ISLSet bottom = body.copy.subtract(body.copy.apply(accumulationMaff.copy.toMap.reverse)).simplify
 		
 		val CaseExpression writeCaseExpr = createCaseExpression()
 		/*
@@ -350,7 +351,7 @@ class SerializeReduction {
 		 */
 		val readCaseExpr = createCaseExpression()
 		val selfDepExpr = createDependenceExpression(
-			reuseDep.copy, 
+			accumulationMaff.copy, 
 			createVariableExpression(reductionVar)
 		)
 		
@@ -381,24 +382,24 @@ class SerializeReduction {
 	/**
 	 * Sanity check!
 	 */
-	static def private void checkArguments(AbstractReduceExpression are, Iterable<ISLMultiAff> reuseDeps, String newName, boolean oneShot) {
+	static def private void checkArguments(AbstractReduceExpression are, Iterable<ISLMultiAff> accumulationMaffs, String newName, boolean oneShot) {
 		val ISLMultiAff writeMaff = are.projectionExpr.getISLMultiAff
 		val nullSpace = writeMaff.copy.nullSpace
 		
-		val Iterable<ISLPoint> reuseVectors = reuseDeps.map[dep | dep.copy.toMap.deltas.samplePoint]
-		if(!reuseVectors.forall[vector | vector.copy.toSet.isSubset(nullSpace.copy)]) {
-			throw new IllegalArgumentException("[SerializeReduction] Reuse dependences: " + reuseDeps +
+		val Iterable<ISLPoint> accumulationVectors = accumulationMaffs.map[accumulationMaff | accumulationMaff.copy.toMap.deltas.samplePoint]
+		if(!accumulationVectors.forall[vector | vector.copy.toSet.isSubset(nullSpace.copy)]) {
+			throw new IllegalArgumentException("[SerializeReduction] Accumulation directions: " + accumulationMaffs +
 				"\ndo not all reside in the nullspace of the projection function: " + are	)
 		}
 		
-		val dimensionality = reuseVectors.getSpan.dimensionality
-		if(dimensionality < reuseVectors.size) {
-			throw new IllegalArgumentException("[SerializeReduction] Reuse dependences: " + reuseDeps +
+		val dimensionality = accumulationVectors.getSpan.dimensionality
+		if(dimensionality < accumulationVectors.size) {
+			throw new IllegalArgumentException("[SerializeReduction] Accumulation directions: " + accumulationMaffs +
 				"\ndo not form a linearly independent set.")
 		}
 		
 		if(dimensionality < nullSpace.copy.dimensionality && !oneShot) {
-			throw new IllegalArgumentException("[SerializeReduction] Reuse dependences " + reuseDeps + 
+			throw new IllegalArgumentException("[SerializeReduction] Accumulation directions " + accumulationMaffs + 
 				" are insufficient to serialize the the given reduction: " + are)
 		}
 		

--- a/bundles/alpha.model/src/alpha/model/transformation/reduction/SerializeReduction.xtend
+++ b/bundles/alpha.model/src/alpha/model/transformation/reduction/SerializeReduction.xtend
@@ -40,13 +40,12 @@ class SerializeReduction {
 	 * Applies a 1D serialization. Can only be used on reductions of rank 1.
 	 */
 	static def void apply(AbstractReduceExpression are, ISLMultiAff reuseDep) {
-		val Variable writeVar = (AlphaUtil.getContainerEquation(are) as StandardEquation).variable
-		val String newName = AlphaUtil.duplicateNameResolver.apply(
-			AlphaUtil.getContainerSystem(are),
-			writeVar.name + "_reduction",
-			"_"
-		)
-		apply(are, reuseDep, newName)
+		apply(are, reuseDep, generateReductionName(are))
+	}
+	
+	static def void apply(AbstractReduceExpression are, ISLMultiAff reuseDep, String newName) {
+		checkArguments(are, #[reuseDep], newName, false)
+		serialize(are, reuseDep, newName)
 	}
 	
 	/**
@@ -58,9 +57,13 @@ class SerializeReduction {
 		SerializeReduction.applySequential(are, nullSpace.getBasisVectors.map[vec | vec.buildTranslationMaff])
 	}
 	
-	static def void apply(AbstractReduceExpression are, ISLMultiAff reuseDep, String newName) {
-		checkArguments(are, #[reuseDep], newName)
-		serialize(are, reuseDep, newName)
+	static def void applyAuto(AbstractReduceExpression are, boolean oneShot) {
+		if(!oneShot) {
+			applyAuto(are)
+			return
+		} 
+		var nullSpace = are.projectionExpr.getISLMultiAff.copy.nullSpace
+		SerializeReduction.applyOneShot(are, nullSpace.getBasisVectors.get(0).buildTranslationMaff)
 	}
 	
 	/**
@@ -69,7 +72,7 @@ class SerializeReduction {
 	 * potential schedule bloat when fed to FoutrierScheduler
 	 */
 	static def void applySequential(AbstractReduceExpression are, Iterable<ISLMultiAff> partialReuseDeps) {
-		checkArguments(are, partialReuseDeps, "")
+		checkArguments(are, partialReuseDeps, "", false)
 		
 		//extend reuseDeps to span the whole nullspace if it isn't long enough.
 		var reuseDeps = partialReuseDeps.map[a | a]
@@ -113,10 +116,22 @@ class SerializeReduction {
 		serialize(are, reuseDeps.get(reuseDeps.length-1), newName)
 	}
 	
+	static def void applyOneShot(AbstractReduceExpression are, ISLMultiAff rho) {
+		applyOneShot(are, rho, generateReductionName(are))
+	}
+	
 	static def void applyOneShot(AbstractReduceExpression are, ISLMultiAff rho, String newName) {
-		//TODO argument checking
-		
+		checkArguments(are, #[rho], newName, false)
 		serializeOneShot(are, rho, newName)
+	}
+	
+	private static def String generateReductionName(AbstractReduceExpression are) {
+		val Variable writeVar = (AlphaUtil.getContainerEquation(are) as StandardEquation).variable
+		return AlphaUtil.duplicateNameResolver.apply(
+			AlphaUtil.getContainerSystem(are),
+			writeVar.name + "_reduction",
+			"_"
+		)
 	}
 	
 	/**
@@ -366,7 +381,7 @@ class SerializeReduction {
 	/**
 	 * Sanity check!
 	 */
-	static def private void checkArguments(AbstractReduceExpression are, Iterable<ISLMultiAff> reuseDeps, String newName) {
+	static def private void checkArguments(AbstractReduceExpression are, Iterable<ISLMultiAff> reuseDeps, String newName, boolean oneShot) {
 		val ISLMultiAff writeMaff = are.projectionExpr.getISLMultiAff
 		val nullSpace = writeMaff.copy.nullSpace
 		
@@ -382,7 +397,7 @@ class SerializeReduction {
 				"\ndo not form a linearly independent set.")
 		}
 		
-		if(dimensionality < nullSpace.copy.dimensionality) {
+		if(dimensionality < nullSpace.copy.dimensionality && !oneShot) {
 			throw new IllegalArgumentException("[SerializeReduction] Reuse dependences " + reuseDeps + 
 				" are insufficient to serialize the the given reduction: " + are)
 		}

--- a/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/AlphaUtil.xtend
@@ -29,6 +29,9 @@ import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.util.EcoreUtil.Copier
 import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider
 import org.eclipse.xtext.naming.IQualifiedNameProvider
+import alpha.model.BINARY_OP
+import alpha.model.BinaryExpression
+import alpha.model.factory.AlphaUserFactory
 
 /**
  * Utility methods for analysis and transformation of Alpha programs.
@@ -418,5 +421,15 @@ class AlphaUtil {
 	
 	static def parseIntVector(String intVecStr) {
 		return parseIntArray(intVecStr).toList
+	}
+	
+	static def AlphaExpression createNaryExpression(BINARY_OP op, Iterable<AlphaExpression> exprs) {
+		if(exprs.size < 1) throw new IllegalArgumentException("exprs must be of size 1 or greater")
+		else if(exprs.size == 1) return exprs.get(0)
+		else return AlphaUserFactory.createBinaryExpression(
+			op,
+			exprs.get(0),
+			createNaryExpression(op, exprs.toList.subList(1, exprs.size))
+		)
 	}
 }

--- a/bundles/alpha.model/src/alpha/model/util/JavaUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/JavaUtil.xtend
@@ -1,0 +1,23 @@
+package alpha.model.util
+
+import java.util.Set
+import java.util.HashSet
+import java.util.Collection
+
+/**
+ * A collection of useful methods that neither Java nor Xtend had the sense to implement
+ */
+class JavaUtil {
+	static def <T> Set<Set<T>> powerSet(Collection<T> set) {
+		if(set.empty)
+			return #[#[].toSet].toSet
+		
+		val list = set.toList
+		val t = list.get(0)
+		val recurseSet = powerSet(list.subList(1, list.size).toSet)
+		
+		return (recurseSet.map[ Set<T> subset |
+			(subset.toList + #[t]).toSet
+		] + recurseSet).toSet
+	}
+}

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SerializeReduction.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SerializeReduction.java
@@ -1,0 +1,218 @@
+package alpha.model.transformation.reduction;
+
+import alpha.model.AbstractReduceExpression;
+import alpha.model.AlphaExpression;
+import alpha.model.AlphaInternalStateConstructor;
+import alpha.model.AlphaSystem;
+import alpha.model.CaseExpression;
+import alpha.model.DependenceExpression;
+import alpha.model.Equation;
+import alpha.model.RestrictExpression;
+import alpha.model.StandardEquation;
+import alpha.model.SystemBody;
+import alpha.model.Variable;
+import alpha.model.VariableExpression;
+import alpha.model.factory.AlphaUserFactory;
+import alpha.model.util.AlphaOperatorUtil;
+import alpha.model.util.AlphaUtil;
+import alpha.model.util.ISLUtil;
+import com.google.common.collect.Iterables;
+import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
+import fr.irisa.cairn.jnimap.isl.ISLMap;
+import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
+import fr.irisa.cairn.jnimap.isl.ISLPoint;
+import fr.irisa.cairn.jnimap.isl.ISLSet;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.Functions.Function3;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
+
+/**
+ * Serializes a reduction along given reuse function(s).
+ * This class is not given enough information to automatically decompose
+ * reductions, so it must serialize all dimensions of the reduction at once.
+ * Users can manually apply DecomposeReduction beforehand if they only wish to
+ * partially serialize the reduction.
+ */
+@SuppressWarnings("all")
+public class SerializeReduction {
+  public static void apply(final AbstractReduceExpression reduce, final ISLMultiAff reuseDep) {
+    Equation _containerEquation = AlphaUtil.getContainerEquation(reduce);
+    final Variable writeVar = ((StandardEquation) _containerEquation).getVariable();
+    Function3<AlphaSystem, String, String, String> _duplicateNameResolver = AlphaUtil.duplicateNameResolver();
+    AlphaSystem _containerSystem = AlphaUtil.getContainerSystem(reduce);
+    String _name = writeVar.getName();
+    String _plus = (_name + "_reduction");
+    final String newName = _duplicateNameResolver.apply(_containerSystem, _plus, 
+      "_");
+    SerializeReduction.apply(reduce, reuseDep, newName);
+  }
+
+  public static void apply(final AbstractReduceExpression reduce, final ISLMultiAff reuseDep, final String newName) {
+    SerializeReduction.checkArguments(reduce, Collections.<ISLMultiAff>unmodifiableList(CollectionLiterals.<ISLMultiAff>newArrayList(reuseDep)), newName);
+    SerializeReduction.serialize(reduce, reuseDep, newName);
+  }
+
+  public static void applyAll(final AbstractReduceExpression reduce, final Iterable<ISLMultiAff> partialReuseDeps) {
+    SerializeReduction.checkArguments(reduce, partialReuseDeps, "");
+    final Function1<ISLMultiAff, ISLMultiAff> _function = (ISLMultiAff a) -> {
+      return a;
+    };
+    Iterable<ISLMultiAff> reuseDeps = IterableExtensions.<ISLMultiAff, ISLMultiAff>map(partialReuseDeps, _function);
+    ISLSet nullSpace = ISLUtil.nullSpace(reduce.getProjectionExpr().getISLMultiAff().copy());
+    int _size = IterableExtensions.size(reuseDeps);
+    int _dimensionality = ISLUtil.dimensionality(nullSpace.copy());
+    boolean _lessThan = (_size < _dimensionality);
+    if (_lessThan) {
+      final Function1<ISLMultiAff, ISLPoint> _function_1 = (ISLMultiAff dep) -> {
+        return dep.copy().toMap().deltas().samplePoint();
+      };
+      final Iterable<ISLPoint> reuseVectors = IterableExtensions.<ISLMultiAff, ISLPoint>map(reuseDeps, _function_1);
+      for (int i = 0; (i < IterableExtensions.size(reuseVectors)); i++) {
+        nullSpace = nullSpace.apply(ISLUtil.buildRejectionMaff((((ISLPoint[])Conversions.unwrapArray(reuseVectors, ISLPoint.class))[i]).copy()).toMap());
+      }
+      final Function1<ISLPoint, ISLMultiAff> _function_2 = (ISLPoint vec) -> {
+        return ISLUtil.buildTranslationMaff(vec);
+      };
+      List<ISLMultiAff> _map = ListExtensions.<ISLPoint, ISLMultiAff>map(ISLUtil.getBasisVectors(nullSpace), _function_2);
+      Iterable<ISLMultiAff> _plus = Iterables.<ISLMultiAff>concat(reuseDeps, _map);
+      reuseDeps = _plus;
+    }
+    Equation _containerEquation = AlphaUtil.getContainerEquation(reduce);
+    final Variable writeVar = ((StandardEquation) _containerEquation).getVariable();
+    for (int i = 0; (i < (((Object[])Conversions.unwrapArray(reuseDeps, Object.class)).length - 1)); i++) {
+      {
+        Function3<AlphaSystem, String, String, String> _duplicateNameResolver = AlphaUtil.duplicateNameResolver();
+        AlphaSystem _containerSystem = AlphaUtil.getContainerSystem(reduce);
+        String _name = writeVar.getName();
+        String _plus_1 = (_name + "_reduction");
+        final String newName = _duplicateNameResolver.apply(_containerSystem, _plus_1, 
+          Integer.valueOf(i).toString());
+        final ISLMultiAff writeMaff = reduce.getProjectionExpr().getISLMultiAff();
+        final Iterable<ISLMultiAff> _converted_reuseDeps = (Iterable<ISLMultiAff>)reuseDeps;
+        final ISLMultiAff reuseDep = ((ISLMultiAff[])Conversions.unwrapArray(_converted_reuseDeps, ISLMultiAff.class))[i];
+        final ISLMultiAff f1 = ISLUtil.buildRejectionMaff(reuseDep.copy().toMap().deltas().samplePoint());
+        final ISLMultiAff f2 = ISLUtil.toMultiAff(writeMaff.copy().toMap().applyDomain(f1.copy().toMap()));
+        ReductionDecomposition.apply(reduce, f1, f2);
+        AlphaExpression _body = reduce.getBody();
+        SerializeReduction.serialize(((AbstractReduceExpression) _body), reuseDep, newName);
+      }
+    }
+    Function3<AlphaSystem, String, String, String> _duplicateNameResolver = AlphaUtil.duplicateNameResolver();
+    AlphaSystem _containerSystem = AlphaUtil.getContainerSystem(reduce);
+    String _name = writeVar.getName();
+    String _plus_1 = (_name + "_reduction");
+    final Iterable<ISLMultiAff> _converted_reuseDeps = (Iterable<ISLMultiAff>)reuseDeps;
+    int _length = ((Object[])Conversions.unwrapArray(_converted_reuseDeps, Object.class)).length;
+    final String newName = _duplicateNameResolver.apply(_containerSystem, _plus_1, 
+      Integer.valueOf((_length - 1)).toString());
+    final Iterable<ISLMultiAff> _converted_reuseDeps_1 = (Iterable<ISLMultiAff>)reuseDeps;
+    final Iterable<ISLMultiAff> _converted_reuseDeps_2 = (Iterable<ISLMultiAff>)reuseDeps;
+    int _length_1 = ((Object[])Conversions.unwrapArray(_converted_reuseDeps_2, Object.class)).length;
+    int _minus = (_length_1 - 1);
+    SerializeReduction.serialize(reduce, ((ISLMultiAff[])Conversions.unwrapArray(_converted_reuseDeps_1, ISLMultiAff.class))[_minus], newName);
+  }
+
+  private static void serialize(final AbstractReduceExpression reduce, final ISLMultiAff reuseDep, final String newName) {
+    AlphaSystem sys = AlphaUtil.getContainerSystem(reduce);
+    final SystemBody systemBody = AlphaUtil.getContainerSystemBody(reduce);
+    final ISLSet body = reduce.getBody().getContextDomain();
+    final ISLMultiAff writeMaff = reduce.getProjectionExpr().getISLMultiAff();
+    AlphaExpression coreExpr = reduce.getBody();
+    if ((coreExpr instanceof RestrictExpression)) {
+      coreExpr = ((RestrictExpression)coreExpr).getExpr();
+    }
+    final Variable reductionVar = AlphaUserFactory.createVariable(newName, body.copy());
+    sys.getLocals().add(reductionVar);
+    final ISLSet top = body.copy().subtract(body.copy().apply(reuseDep.copy().toMap())).simplify();
+    final ISLSet bottom = body.copy().subtract(body.copy().apply(reuseDep.copy().toMap().reverse())).simplify();
+    final CaseExpression writeCaseExpr = AlphaUserFactory.createCaseExpression();
+    ISLSet coveredDomain = ISLSet.buildEmpty(body.copy().apply(writeMaff.copy().toMap()).getSpace());
+    List<ISLBasicSet> _basicSets = top.getBasicSets();
+    for (final ISLBasicSet basicFacet : _basicSets) {
+      {
+        final ISLSet facet = basicFacet.copy().toSet();
+        final ISLMap shadowProject = writeMaff.copy().toMap().intersectDomain(facet.copy());
+        final ISLSet shadow = facet.copy().apply(shadowProject.copy()).subtract(coveredDomain.copy());
+        coveredDomain = coveredDomain.union(shadow.copy());
+        final VariableExpression readExpr = AlphaUserFactory.createVariableExpression(reductionVar);
+        AlphaExpression dependenceExpr = null;
+        boolean _isSingleValued = shadowProject.copy().reverse().isSingleValued();
+        if (_isSingleValued) {
+          dependenceExpr = AlphaUserFactory.createDependenceExpression(
+            ISLUtil.toMultiAff(shadowProject.copy().reverse()), readExpr);
+        } else {
+          dependenceExpr = AlphaUserFactory.createReduceExpression(
+            reduce.getOperator(), 
+            writeMaff.copy(), 
+            AlphaUserFactory.createRestrictExpression(
+              top.copy(), readExpr));
+        }
+        EList<AlphaExpression> _exprs = writeCaseExpr.getExprs();
+        RestrictExpression _createRestrictExpression = AlphaUserFactory.createRestrictExpression(shadow, dependenceExpr);
+        _exprs.add(_createRestrictExpression);
+      }
+    }
+    EcoreUtil.replace(reduce, writeCaseExpr);
+    final CaseExpression readCaseExpr = AlphaUserFactory.createCaseExpression();
+    final DependenceExpression selfDepExpr = AlphaUserFactory.createDependenceExpression(
+      reuseDep.copy(), 
+      AlphaUserFactory.createVariableExpression(reductionVar));
+    EList<AlphaExpression> _exprs = readCaseExpr.getExprs();
+    RestrictExpression _createRestrictExpression = AlphaUserFactory.createRestrictExpression(
+      bottom.copy(), 
+      EcoreUtil.<AlphaExpression>copy(coreExpr));
+    _exprs.add(_createRestrictExpression);
+    EList<AlphaExpression> _exprs_1 = readCaseExpr.getExprs();
+    RestrictExpression _createRestrictExpression_1 = AlphaUserFactory.createRestrictExpression(
+      body.copy().subtract(bottom.copy()), 
+      AlphaUserFactory.createBinaryExpression(
+        AlphaOperatorUtil.reductionOPtoBinaryOP(reduce.getOperator()), 
+        EcoreUtil.<AlphaExpression>copy(coreExpr), selfDepExpr));
+    _exprs_1.add(_createRestrictExpression_1);
+    final StandardEquation standardEq = AlphaUserFactory.createStandardEquation(reductionVar, readCaseExpr);
+    EList<Equation> _equations = systemBody.getEquations();
+    _equations.add(standardEq);
+    AlphaInternalStateConstructor.recomputeContextDomain(sys);
+  }
+
+  private static void checkArguments(final AbstractReduceExpression reduce, final Iterable<ISLMultiAff> reuseDeps, final String newName) {
+    final ISLMultiAff writeMaff = reduce.getProjectionExpr().getISLMultiAff();
+    final ISLSet nullSpace = ISLUtil.nullSpace(writeMaff.copy());
+    final Function1<ISLMultiAff, ISLPoint> _function = (ISLMultiAff dep) -> {
+      return dep.copy().toMap().deltas().samplePoint();
+    };
+    final Iterable<ISLPoint> reuseVectors = IterableExtensions.<ISLMultiAff, ISLPoint>map(reuseDeps, _function);
+    final Function1<ISLPoint, Boolean> _function_1 = (ISLPoint vector) -> {
+      return Boolean.valueOf(vector.copy().toSet().isSubset(nullSpace.copy()));
+    };
+    boolean _forall = IterableExtensions.<ISLPoint>forall(reuseVectors, _function_1);
+    boolean _not = (!_forall);
+    if (_not) {
+      throw new IllegalArgumentException(((("[SerializeReduction] Reuse dependences: " + reuseDeps) + 
+        "\ndo not all reside in the nullspace of the projection function: ") + reduce));
+    }
+    final int dimensionality = ISLUtil.dimensionality(ISLUtil.getSpan(reuseVectors));
+    int _size = IterableExtensions.size(reuseVectors);
+    boolean _lessThan = (dimensionality < _size);
+    if (_lessThan) {
+      throw new IllegalArgumentException((("[SerializeReduction] Reuse dependences: " + reuseDeps) + 
+        "\ndo not form a linearly independent set."));
+    }
+    AlphaSystem sys = AlphaUtil.getContainerSystem(reduce);
+    if ((sys == null)) {
+      throw new IllegalArgumentException("[SerializeReduction] Reduction Expression has no containing system.");
+    }
+    Variable _variable = sys.getVariable(newName);
+    boolean _tripleNotEquals = (_variable != null);
+    if (_tripleNotEquals) {
+      throw new IllegalArgumentException((("[SerializeReduction] Variable with name " + newName) + " already exists in the system."));
+    }
+  }
+}

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SerializeReduction.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SerializeReduction.java
@@ -58,15 +58,12 @@ public class SerializeReduction {
    * Applies a 1D serialization. Can only be used on reductions of rank 1.
    */
   public static void apply(final AbstractReduceExpression are, final ISLMultiAff reuseDep) {
-    Equation _containerEquation = AlphaUtil.getContainerEquation(are);
-    final Variable writeVar = ((StandardEquation) _containerEquation).getVariable();
-    Function3<AlphaSystem, String, String, String> _duplicateNameResolver = AlphaUtil.duplicateNameResolver();
-    AlphaSystem _containerSystem = AlphaUtil.getContainerSystem(are);
-    String _name = writeVar.getName();
-    String _plus = (_name + "_reduction");
-    final String newName = _duplicateNameResolver.apply(_containerSystem, _plus, 
-      "_");
-    SerializeReduction.apply(are, reuseDep, newName);
+    SerializeReduction.apply(are, reuseDep, SerializeReduction.generateReductionName(are));
+  }
+
+  public static void apply(final AbstractReduceExpression are, final ISLMultiAff reuseDep, final String newName) {
+    SerializeReduction.checkArguments(are, Collections.<ISLMultiAff>unmodifiableList(CollectionLiterals.<ISLMultiAff>newArrayList(reuseDep)), newName, false);
+    SerializeReduction.serialize(are, reuseDep, newName);
   }
 
   /**
@@ -81,9 +78,13 @@ public class SerializeReduction {
     SerializeReduction.applySequential(are, ListExtensions.<ISLPoint, ISLMultiAff>map(ISLUtil.getBasisVectors(nullSpace), _function));
   }
 
-  public static void apply(final AbstractReduceExpression are, final ISLMultiAff reuseDep, final String newName) {
-    SerializeReduction.checkArguments(are, Collections.<ISLMultiAff>unmodifiableList(CollectionLiterals.<ISLMultiAff>newArrayList(reuseDep)), newName);
-    SerializeReduction.serialize(are, reuseDep, newName);
+  public static void applyAuto(final AbstractReduceExpression are, final boolean oneShot) {
+    if ((!oneShot)) {
+      SerializeReduction.applyAuto(are);
+      return;
+    }
+    ISLSet nullSpace = ISLUtil.nullSpace(are.getProjectionExpr().getISLMultiAff().copy());
+    SerializeReduction.applyOneShot(are, ISLUtil.buildTranslationMaff(ISLUtil.getBasisVectors(nullSpace).get(0)));
   }
 
   /**
@@ -92,7 +93,7 @@ public class SerializeReduction {
    * potential schedule bloat when fed to FoutrierScheduler
    */
   public static void applySequential(final AbstractReduceExpression are, final Iterable<ISLMultiAff> partialReuseDeps) {
-    SerializeReduction.checkArguments(are, partialReuseDeps, "");
+    SerializeReduction.checkArguments(are, partialReuseDeps, "", false);
     final Function1<ISLMultiAff, ISLMultiAff> _function = (ISLMultiAff a) -> {
       return a;
     };
@@ -151,8 +152,24 @@ public class SerializeReduction {
     SerializeReduction.serialize(are, ((ISLMultiAff[])Conversions.unwrapArray(_converted_reuseDeps_1, ISLMultiAff.class))[_minus], newName);
   }
 
+  public static void applyOneShot(final AbstractReduceExpression are, final ISLMultiAff rho) {
+    SerializeReduction.applyOneShot(are, rho, SerializeReduction.generateReductionName(are));
+  }
+
   public static void applyOneShot(final AbstractReduceExpression are, final ISLMultiAff rho, final String newName) {
+    SerializeReduction.checkArguments(are, Collections.<ISLMultiAff>unmodifiableList(CollectionLiterals.<ISLMultiAff>newArrayList(rho)), newName, false);
     SerializeReduction.serializeOneShot(are, rho, newName);
+  }
+
+  private static String generateReductionName(final AbstractReduceExpression are) {
+    Equation _containerEquation = AlphaUtil.getContainerEquation(are);
+    final Variable writeVar = ((StandardEquation) _containerEquation).getVariable();
+    Function3<AlphaSystem, String, String, String> _duplicateNameResolver = AlphaUtil.duplicateNameResolver();
+    AlphaSystem _containerSystem = AlphaUtil.getContainerSystem(are);
+    String _name = writeVar.getName();
+    String _plus = (_name + "_reduction");
+    return _duplicateNameResolver.apply(_containerSystem, _plus, 
+      "_");
   }
 
   /**
@@ -362,7 +379,7 @@ public class SerializeReduction {
   /**
    * Sanity check!
    */
-  private static void checkArguments(final AbstractReduceExpression are, final Iterable<ISLMultiAff> reuseDeps, final String newName) {
+  private static void checkArguments(final AbstractReduceExpression are, final Iterable<ISLMultiAff> reuseDeps, final String newName, final boolean oneShot) {
     final ISLMultiAff writeMaff = are.getProjectionExpr().getISLMultiAff();
     final ISLSet nullSpace = ISLUtil.nullSpace(writeMaff.copy());
     final Function1<ISLMultiAff, ISLPoint> _function = (ISLMultiAff dep) -> {
@@ -385,9 +402,7 @@ public class SerializeReduction {
       throw new IllegalArgumentException((("[SerializeReduction] Reuse dependences: " + reuseDeps) + 
         "\ndo not form a linearly independent set."));
     }
-    int _dimensionality = ISLUtil.dimensionality(nullSpace.copy());
-    boolean _lessThan_1 = (dimensionality < _dimensionality);
-    if (_lessThan_1) {
+    if (((dimensionality < ISLUtil.dimensionality(nullSpace.copy())) && (!oneShot))) {
       throw new IllegalArgumentException(((("[SerializeReduction] Reuse dependences " + reuseDeps) + 
         " are insufficient to serialize the the given reduction: ") + are));
     }

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SerializeReduction.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SerializeReduction.java
@@ -47,27 +47,29 @@ import org.eclipse.xtext.xbase.lib.ListExtensions;
  * 
  * This will modify the container system of the given ReduceExpression.
  * 
- * This class is not given enough information to automatically decompose
- * reductions, so it must serialize all dimensions of the reduction at once.
- * Users can manually apply DecomposeReduction beforehand if they only wish to
- * partially serialize the reduction.
+ * Three methods are included:
+ * - apply: serializes a reduction of rank 1 with a single accumulation vector.
+ * - applyAuto: serializes a reduction with automatically generated accumulation vectors.
+ * - applySequential: serializes a reduction of rank n with up to n accumulation vectors
+ * 		(more accumulation vectors are automatically generated as needed).
+ * - applyOneShot: serializes a reduction of any rank with a single accumulation vector.
  */
 @SuppressWarnings("all")
 public class SerializeReduction {
   /**
    * Applies a 1D serialization. Can only be used on reductions of rank 1.
    */
-  public static void apply(final AbstractReduceExpression are, final ISLMultiAff reuseDep) {
-    SerializeReduction.apply(are, reuseDep, SerializeReduction.generateReductionName(are));
+  public static void apply(final AbstractReduceExpression are, final ISLMultiAff accumulationMaff) {
+    SerializeReduction.apply(are, accumulationMaff, SerializeReduction.generateReductionName(are));
   }
 
-  public static void apply(final AbstractReduceExpression are, final ISLMultiAff reuseDep, final String newName) {
-    SerializeReduction.checkArguments(are, Collections.<ISLMultiAff>unmodifiableList(CollectionLiterals.<ISLMultiAff>newArrayList(reuseDep)), newName, false);
-    SerializeReduction.serialize(are, reuseDep, newName);
+  public static void apply(final AbstractReduceExpression are, final ISLMultiAff accumulationMaff, final String newName) {
+    SerializeReduction.checkArguments(are, Collections.<ISLMultiAff>unmodifiableList(CollectionLiterals.<ISLMultiAff>newArrayList(accumulationMaff)), newName, false);
+    SerializeReduction.serialize(are, accumulationMaff, newName);
   }
 
   /**
-   * Serializes a reduction using an arbitrary set of basis vectors as reuse dependences.
+   * Serializes a reduction using an arbitrary set of basis vectors as directions of accumulation.
    * This is not guaranteed to be a 'good' serialization, but it will certainly be valid.
    */
   public static void applyAuto(final AbstractReduceExpression are) {
@@ -92,34 +94,34 @@ public class SerializeReduction {
    * Avoids a potentially exponential number of domains, at the cost of
    * potential schedule bloat when fed to FoutrierScheduler
    */
-  public static void applySequential(final AbstractReduceExpression are, final Iterable<ISLMultiAff> partialReuseDeps) {
-    SerializeReduction.checkArguments(are, partialReuseDeps, "", false);
+  public static void applySequential(final AbstractReduceExpression are, final Iterable<ISLMultiAff> partialaccumulationMaffs) {
+    SerializeReduction.checkArguments(are, partialaccumulationMaffs, "", false);
     final Function1<ISLMultiAff, ISLMultiAff> _function = (ISLMultiAff a) -> {
       return a;
     };
-    Iterable<ISLMultiAff> reuseDeps = IterableExtensions.<ISLMultiAff, ISLMultiAff>map(partialReuseDeps, _function);
+    Iterable<ISLMultiAff> accumulationMaffs = IterableExtensions.<ISLMultiAff, ISLMultiAff>map(partialaccumulationMaffs, _function);
     ISLSet nullSpace = ISLUtil.nullSpace(are.getProjectionExpr().getISLMultiAff().copy());
-    int _size = IterableExtensions.size(reuseDeps);
+    int _size = IterableExtensions.size(accumulationMaffs);
     int _dimensionality = ISLUtil.dimensionality(nullSpace.copy());
     boolean _lessThan = (_size < _dimensionality);
     if (_lessThan) {
-      final Function1<ISLMultiAff, ISLPoint> _function_1 = (ISLMultiAff dep) -> {
-        return dep.copy().toMap().deltas().samplePoint();
+      final Function1<ISLMultiAff, ISLPoint> _function_1 = (ISLMultiAff accumulationMaff) -> {
+        return accumulationMaff.copy().toMap().deltas().samplePoint();
       };
-      final Iterable<ISLPoint> reuseVectors = IterableExtensions.<ISLMultiAff, ISLPoint>map(reuseDeps, _function_1);
-      for (int i = 0; (i < IterableExtensions.size(reuseVectors)); i++) {
-        nullSpace = nullSpace.apply(ISLUtil.buildRejectionMaff((((ISLPoint[])Conversions.unwrapArray(reuseVectors, ISLPoint.class))[i]).copy()).toMap());
+      final Iterable<ISLPoint> accumulationVectors = IterableExtensions.<ISLMultiAff, ISLPoint>map(accumulationMaffs, _function_1);
+      for (int i = 0; (i < IterableExtensions.size(accumulationVectors)); i++) {
+        nullSpace = nullSpace.apply(ISLUtil.buildRejectionMaff((((ISLPoint[])Conversions.unwrapArray(accumulationVectors, ISLPoint.class))[i]).copy()).toMap());
       }
       final Function1<ISLPoint, ISLMultiAff> _function_2 = (ISLPoint vec) -> {
         return ISLUtil.buildTranslationMaff(vec);
       };
       List<ISLMultiAff> _map = ListExtensions.<ISLPoint, ISLMultiAff>map(ISLUtil.getBasisVectors(nullSpace), _function_2);
-      Iterable<ISLMultiAff> _plus = Iterables.<ISLMultiAff>concat(reuseDeps, _map);
-      reuseDeps = _plus;
+      Iterable<ISLMultiAff> _plus = Iterables.<ISLMultiAff>concat(accumulationMaffs, _map);
+      accumulationMaffs = _plus;
     }
     Equation _containerEquation = AlphaUtil.getContainerEquation(are);
     final Variable writeVar = ((StandardEquation) _containerEquation).getVariable();
-    for (int i = 0; (i < (((Object[])Conversions.unwrapArray(reuseDeps, Object.class)).length - 1)); i++) {
+    for (int i = 0; (i < (((Object[])Conversions.unwrapArray(accumulationMaffs, Object.class)).length - 1)); i++) {
       {
         Function3<AlphaSystem, String, String, String> _duplicateNameResolver = AlphaUtil.duplicateNameResolver();
         AlphaSystem _containerSystem = AlphaUtil.getContainerSystem(are);
@@ -128,37 +130,37 @@ public class SerializeReduction {
         final String newName = _duplicateNameResolver.apply(_containerSystem, _plus_1, 
           Integer.valueOf(i).toString());
         final ISLMultiAff writeMaff = are.getProjectionExpr().getISLMultiAff();
-        final Iterable<ISLMultiAff> _converted_reuseDeps = (Iterable<ISLMultiAff>)reuseDeps;
-        final ISLMultiAff reuseDep = ((ISLMultiAff[])Conversions.unwrapArray(_converted_reuseDeps, ISLMultiAff.class))[i];
-        final ISLMultiAff f1 = ISLUtil.buildRejectionMaff(reuseDep.copy().toMap().deltas().samplePoint());
+        final Iterable<ISLMultiAff> _converted_accumulationMaffs = (Iterable<ISLMultiAff>)accumulationMaffs;
+        final ISLMultiAff accumulationMaff = ((ISLMultiAff[])Conversions.unwrapArray(_converted_accumulationMaffs, ISLMultiAff.class))[i];
+        final ISLMultiAff f1 = ISLUtil.buildRejectionMaff(accumulationMaff.copy().toMap().deltas().samplePoint());
         final ISLMultiAff f2 = ISLUtil.toMultiAff(writeMaff.copy().toMap().applyDomain(f1.copy().toMap()));
         ReductionDecomposition.apply(are, f1, f2);
         AlphaExpression _body = are.getBody();
-        SerializeReduction.serialize(((AbstractReduceExpression) _body), reuseDep, newName);
+        SerializeReduction.serialize(((AbstractReduceExpression) _body), accumulationMaff, newName);
       }
     }
     Function3<AlphaSystem, String, String, String> _duplicateNameResolver = AlphaUtil.duplicateNameResolver();
     AlphaSystem _containerSystem = AlphaUtil.getContainerSystem(are);
     String _name = writeVar.getName();
     String _plus_1 = (_name + "_reduction");
-    final Iterable<ISLMultiAff> _converted_reuseDeps = (Iterable<ISLMultiAff>)reuseDeps;
-    int _length = ((Object[])Conversions.unwrapArray(_converted_reuseDeps, Object.class)).length;
+    final Iterable<ISLMultiAff> _converted_accumulationMaffs = (Iterable<ISLMultiAff>)accumulationMaffs;
+    int _length = ((Object[])Conversions.unwrapArray(_converted_accumulationMaffs, Object.class)).length;
     final String newName = _duplicateNameResolver.apply(_containerSystem, _plus_1, 
       Integer.valueOf((_length - 1)).toString());
-    final Iterable<ISLMultiAff> _converted_reuseDeps_1 = (Iterable<ISLMultiAff>)reuseDeps;
-    final Iterable<ISLMultiAff> _converted_reuseDeps_2 = (Iterable<ISLMultiAff>)reuseDeps;
-    int _length_1 = ((Object[])Conversions.unwrapArray(_converted_reuseDeps_2, Object.class)).length;
+    final Iterable<ISLMultiAff> _converted_accumulationMaffs_1 = (Iterable<ISLMultiAff>)accumulationMaffs;
+    final Iterable<ISLMultiAff> _converted_accumulationMaffs_2 = (Iterable<ISLMultiAff>)accumulationMaffs;
+    int _length_1 = ((Object[])Conversions.unwrapArray(_converted_accumulationMaffs_2, Object.class)).length;
     int _minus = (_length_1 - 1);
-    SerializeReduction.serialize(are, ((ISLMultiAff[])Conversions.unwrapArray(_converted_reuseDeps_1, ISLMultiAff.class))[_minus], newName);
+    SerializeReduction.serialize(are, ((ISLMultiAff[])Conversions.unwrapArray(_converted_accumulationMaffs_1, ISLMultiAff.class))[_minus], newName);
   }
 
-  public static void applyOneShot(final AbstractReduceExpression are, final ISLMultiAff rho) {
-    SerializeReduction.applyOneShot(are, rho, SerializeReduction.generateReductionName(are));
+  public static void applyOneShot(final AbstractReduceExpression are, final ISLMultiAff accumulationMaff) {
+    SerializeReduction.applyOneShot(are, accumulationMaff, SerializeReduction.generateReductionName(are));
   }
 
-  public static void applyOneShot(final AbstractReduceExpression are, final ISLMultiAff rho, final String newName) {
-    SerializeReduction.checkArguments(are, Collections.<ISLMultiAff>unmodifiableList(CollectionLiterals.<ISLMultiAff>newArrayList(rho)), newName, false);
-    SerializeReduction.serializeOneShot(are, rho, newName);
+  public static void applyOneShot(final AbstractReduceExpression are, final ISLMultiAff accumulationMaff, final String newName) {
+    SerializeReduction.checkArguments(are, Collections.<ISLMultiAff>unmodifiableList(CollectionLiterals.<ISLMultiAff>newArrayList(accumulationMaff)), newName, false);
+    SerializeReduction.serializeOneShot(are, accumulationMaff, newName);
   }
 
   private static String generateReductionName(final AbstractReduceExpression are) {
@@ -177,7 +179,7 @@ public class SerializeReduction {
    * May have an exponential number of domains
    * But avoids schedule bloat from having more variables than needed
    */
-  private static void serializeOneShot(final AbstractReduceExpression are, final ISLMultiAff rho, final String newName) {
+  private static void serializeOneShot(final AbstractReduceExpression are, final ISLMultiAff accumulationMaff, final String newName) {
     final ISLSet body = are.getBody().getContextDomain();
     final ISLMultiAff writeMaff = are.getProjectionExpr().getISLMultiAff();
     AlphaExpression coreExpr = are.getBody();
@@ -187,12 +189,12 @@ public class SerializeReduction {
     AlphaSystem sys = AlphaUtil.getContainerSystem(are);
     final Variable reductionVar = AlphaUserFactory.createVariable(newName, body.copy());
     sys.getLocals().add(reductionVar);
-    final ISLSet basin = body.copy().intersect(body.copy().apply(rho.copy().toMap().reverse()));
+    final ISLSet basin = body.copy().intersect(body.copy().apply(accumulationMaff.copy().toMap().reverse()));
     final ISLSet top = body.copy().subtract(basin.copy()).simplify();
-    final ISLSet bottom = body.copy().subtract(body.copy().apply(rho.copy().toMap())).simplify();
+    final ISLSet bottom = body.copy().subtract(body.copy().apply(accumulationMaff.copy().toMap())).simplify();
     final FaceLattice lattice = FaceLattice.create(body.getBasicSetAt(0).copy());
-    final ISLSet rhoProjPreimage = rho.copy().toMap().deltas().preimage(
-      ISLUtil.buildProjectionMaff(rho.copy().toMap().deltas().samplePoint()));
+    final ISLSet accumulationMaffProjPreimage = accumulationMaff.copy().toMap().deltas().preimage(
+      ISLUtil.buildProjectionMaff(accumulationMaff.copy().toMap().deltas().samplePoint()));
     int _dim = body.dim(ISLDimType.isl_dim_set);
     int _dimensionality = ISLUtil.dimensionality(ISLUtil.nullSpace(writeMaff.copy()));
     final int nExtraDims = (_dim - _dimensionality);
@@ -205,7 +207,7 @@ public class SerializeReduction {
     final Function1<ISLSet, ISLSet> _function_2 = (ISLSet set) -> {
       return ISLUtil.getSpan(ISLUtil.getBasisVectors(set)).intersect(
         ISLUtil.nullSpace(writeMaff.copy())).intersect(
-        rhoProjPreimage.copy());
+        accumulationMaffProjPreimage.copy());
     };
     final Function1<ISLSet, Boolean> _function_3 = (ISLSet set) -> {
       boolean _isEmpty = set.isEmpty();
@@ -219,7 +221,7 @@ public class SerializeReduction {
     ArrayList<ISLMap> infoFlowMaps = new ArrayList<ISLMap>();
     for (final ISLPoint vec : edgeFlowVecs) {
       {
-        final ISLSet accumulatedPoints = top.copy().intersect(top.copy().apply(rho.copy().toMap().reverse()));
+        final ISLSet accumulatedPoints = top.copy().intersect(top.copy().apply(accumulationMaff.copy().toMap().reverse()));
         boolean _isEmpty = accumulatedPoints.isEmpty();
         boolean _not = (!_isEmpty);
         if (_not) {
@@ -229,7 +231,7 @@ public class SerializeReduction {
         }
       }
     }
-    ISLMap _intersectDomain = rho.copy().toMap().intersectDomain(basin);
+    ISLMap _intersectDomain = accumulationMaff.copy().toMap().intersectDomain(basin);
     infoFlowMaps.add(_intersectDomain);
     CaseExpression cases = SerializeReduction.infoFlowToCases(infoFlowMaps, 
       AlphaOperatorUtil.reductionOPtoBinaryOP(are.getOperator()), reductionVar, coreExpr);
@@ -311,9 +313,9 @@ public class SerializeReduction {
   }
 
   /**
-   * The main serialize method, which all public-facing methods eventually call.
+   * The main serialize method, which apply and applyAll eventually call.
    */
-  private static void serialize(final AbstractReduceExpression are, final ISLMultiAff reuseDep, final String newName) {
+  private static void serialize(final AbstractReduceExpression are, final ISLMultiAff accumulationMaff, final String newName) {
     AlphaSystem sys = AlphaUtil.getContainerSystem(are);
     final SystemBody systemBody = AlphaUtil.getContainerSystemBody(are);
     final ISLSet body = are.getBody().getContextDomain();
@@ -324,8 +326,8 @@ public class SerializeReduction {
     }
     final Variable reductionVar = AlphaUserFactory.createVariable(newName, body.copy());
     sys.getLocals().add(reductionVar);
-    final ISLSet top = body.copy().subtract(body.copy().apply(reuseDep.copy().toMap())).simplify();
-    final ISLSet bottom = body.copy().subtract(body.copy().apply(reuseDep.copy().toMap().reverse())).simplify();
+    final ISLSet top = body.copy().subtract(body.copy().apply(accumulationMaff.copy().toMap())).simplify();
+    final ISLSet bottom = body.copy().subtract(body.copy().apply(accumulationMaff.copy().toMap().reverse())).simplify();
     final CaseExpression writeCaseExpr = AlphaUserFactory.createCaseExpression();
     ISLSet coveredDomain = ISLSet.buildEmpty(body.copy().apply(writeMaff.copy().toMap()).getSpace());
     List<ISLBasicSet> _basicSets = top.getBasicSets();
@@ -356,7 +358,7 @@ public class SerializeReduction {
     EcoreUtil.replace(are, writeCaseExpr);
     final CaseExpression readCaseExpr = AlphaUserFactory.createCaseExpression();
     final DependenceExpression selfDepExpr = AlphaUserFactory.createDependenceExpression(
-      reuseDep.copy(), 
+      accumulationMaff.copy(), 
       AlphaUserFactory.createVariableExpression(reductionVar));
     EList<AlphaExpression> _exprs = readCaseExpr.getExprs();
     RestrictExpression _createRestrictExpression = AlphaUserFactory.createRestrictExpression(
@@ -379,31 +381,31 @@ public class SerializeReduction {
   /**
    * Sanity check!
    */
-  private static void checkArguments(final AbstractReduceExpression are, final Iterable<ISLMultiAff> reuseDeps, final String newName, final boolean oneShot) {
+  private static void checkArguments(final AbstractReduceExpression are, final Iterable<ISLMultiAff> accumulationMaffs, final String newName, final boolean oneShot) {
     final ISLMultiAff writeMaff = are.getProjectionExpr().getISLMultiAff();
     final ISLSet nullSpace = ISLUtil.nullSpace(writeMaff.copy());
-    final Function1<ISLMultiAff, ISLPoint> _function = (ISLMultiAff dep) -> {
-      return dep.copy().toMap().deltas().samplePoint();
+    final Function1<ISLMultiAff, ISLPoint> _function = (ISLMultiAff accumulationMaff) -> {
+      return accumulationMaff.copy().toMap().deltas().samplePoint();
     };
-    final Iterable<ISLPoint> reuseVectors = IterableExtensions.<ISLMultiAff, ISLPoint>map(reuseDeps, _function);
+    final Iterable<ISLPoint> accumulationVectors = IterableExtensions.<ISLMultiAff, ISLPoint>map(accumulationMaffs, _function);
     final Function1<ISLPoint, Boolean> _function_1 = (ISLPoint vector) -> {
       return Boolean.valueOf(vector.copy().toSet().isSubset(nullSpace.copy()));
     };
-    boolean _forall = IterableExtensions.<ISLPoint>forall(reuseVectors, _function_1);
+    boolean _forall = IterableExtensions.<ISLPoint>forall(accumulationVectors, _function_1);
     boolean _not = (!_forall);
     if (_not) {
-      throw new IllegalArgumentException(((("[SerializeReduction] Reuse dependences: " + reuseDeps) + 
+      throw new IllegalArgumentException(((("[SerializeReduction] Accumulation directions: " + accumulationMaffs) + 
         "\ndo not all reside in the nullspace of the projection function: ") + are));
     }
-    final int dimensionality = ISLUtil.dimensionality(ISLUtil.getSpan(reuseVectors));
-    int _size = IterableExtensions.size(reuseVectors);
+    final int dimensionality = ISLUtil.dimensionality(ISLUtil.getSpan(accumulationVectors));
+    int _size = IterableExtensions.size(accumulationVectors);
     boolean _lessThan = (dimensionality < _size);
     if (_lessThan) {
-      throw new IllegalArgumentException((("[SerializeReduction] Reuse dependences: " + reuseDeps) + 
+      throw new IllegalArgumentException((("[SerializeReduction] Accumulation directions: " + accumulationMaffs) + 
         "\ndo not form a linearly independent set."));
     }
     if (((dimensionality < ISLUtil.dimensionality(nullSpace.copy())) && (!oneShot))) {
-      throw new IllegalArgumentException(((("[SerializeReduction] Reuse dependences " + reuseDeps) + 
+      throw new IllegalArgumentException(((("[SerializeReduction] Accumulation directions " + accumulationMaffs) + 
         " are insufficient to serialize the the given reduction: ") + are));
     }
     AlphaSystem sys = AlphaUtil.getContainerSystem(are);

--- a/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SerializeReduction.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/transformation/reduction/SerializeReduction.java
@@ -4,6 +4,7 @@ import alpha.model.AbstractReduceExpression;
 import alpha.model.AlphaExpression;
 import alpha.model.AlphaInternalStateConstructor;
 import alpha.model.AlphaSystem;
+import alpha.model.BINARY_OP;
 import alpha.model.CaseExpression;
 import alpha.model.DependenceExpression;
 import alpha.model.Equation;
@@ -15,20 +16,28 @@ import alpha.model.VariableExpression;
 import alpha.model.factory.AlphaUserFactory;
 import alpha.model.util.AlphaOperatorUtil;
 import alpha.model.util.AlphaUtil;
+import alpha.model.util.Face;
+import alpha.model.util.FaceLattice;
 import alpha.model.util.ISLUtil;
+import alpha.model.util.JavaUtil;
 import com.google.common.collect.Iterables;
 import fr.irisa.cairn.jnimap.isl.ISLBasicSet;
+import fr.irisa.cairn.jnimap.isl.ISLDimType;
 import fr.irisa.cairn.jnimap.isl.ISLMap;
 import fr.irisa.cairn.jnimap.isl.ISLMultiAff;
 import fr.irisa.cairn.jnimap.isl.ISLPoint;
 import fr.irisa.cairn.jnimap.isl.ISLSet;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.Functions.Function2;
 import org.eclipse.xtext.xbase.lib.Functions.Function3;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
@@ -69,7 +78,7 @@ public class SerializeReduction {
     final Function1<ISLPoint, ISLMultiAff> _function = (ISLPoint vec) -> {
       return ISLUtil.buildTranslationMaff(vec);
     };
-    SerializeReduction.applyAll(are, ListExtensions.<ISLPoint, ISLMultiAff>map(ISLUtil.getBasisVectors(nullSpace), _function));
+    SerializeReduction.applySequential(are, ListExtensions.<ISLPoint, ISLMultiAff>map(ISLUtil.getBasisVectors(nullSpace), _function));
   }
 
   public static void apply(final AbstractReduceExpression are, final ISLMultiAff reuseDep, final String newName) {
@@ -77,7 +86,12 @@ public class SerializeReduction {
     SerializeReduction.serialize(are, reuseDep, newName);
   }
 
-  public static void applyAll(final AbstractReduceExpression are, final Iterable<ISLMultiAff> partialReuseDeps) {
+  /**
+   * Applies a series of reductions, creating a new temporary variable for each.
+   * Avoids a potentially exponential number of domains, at the cost of
+   * potential schedule bloat when fed to FoutrierScheduler
+   */
+  public static void applySequential(final AbstractReduceExpression are, final Iterable<ISLMultiAff> partialReuseDeps) {
     SerializeReduction.checkArguments(are, partialReuseDeps, "");
     final Function1<ISLMultiAff, ISLMultiAff> _function = (ISLMultiAff a) -> {
       return a;
@@ -135,6 +149,148 @@ public class SerializeReduction {
     int _length_1 = ((Object[])Conversions.unwrapArray(_converted_reuseDeps_2, Object.class)).length;
     int _minus = (_length_1 - 1);
     SerializeReduction.serialize(are, ((ISLMultiAff[])Conversions.unwrapArray(_converted_reuseDeps_1, ISLMultiAff.class))[_minus], newName);
+  }
+
+  public static void applyOneShot(final AbstractReduceExpression are, final ISLMultiAff rho, final String newName) {
+    SerializeReduction.serializeOneShot(are, rho, newName);
+  }
+
+  /**
+   * Serialize a reduction using only one accumulation vector
+   * May have an exponential number of domains
+   * But avoids schedule bloat from having more variables than needed
+   */
+  private static void serializeOneShot(final AbstractReduceExpression are, final ISLMultiAff rho, final String newName) {
+    final ISLSet body = are.getBody().getContextDomain();
+    final ISLMultiAff writeMaff = are.getProjectionExpr().getISLMultiAff();
+    AlphaExpression coreExpr = are.getBody();
+    if ((coreExpr instanceof RestrictExpression)) {
+      coreExpr = ((RestrictExpression)coreExpr).getExpr();
+    }
+    AlphaSystem sys = AlphaUtil.getContainerSystem(are);
+    final Variable reductionVar = AlphaUserFactory.createVariable(newName, body.copy());
+    sys.getLocals().add(reductionVar);
+    final ISLSet basin = body.copy().intersect(body.copy().apply(rho.copy().toMap().reverse()));
+    final ISLSet top = body.copy().subtract(basin.copy()).simplify();
+    final ISLSet bottom = body.copy().subtract(body.copy().apply(rho.copy().toMap())).simplify();
+    final FaceLattice lattice = FaceLattice.create(body.getBasicSetAt(0).copy());
+    final ISLSet rhoProjPreimage = rho.copy().toMap().deltas().preimage(
+      ISLUtil.buildProjectionMaff(rho.copy().toMap().deltas().samplePoint()));
+    int _dim = body.dim(ISLDimType.isl_dim_set);
+    int _dimensionality = ISLUtil.dimensionality(ISLUtil.nullSpace(writeMaff.copy()));
+    final int nExtraDims = (_dim - _dimensionality);
+    final Function1<Face, ISLSet> _function = (Face edge) -> {
+      return edge.toBasicSet().toSet();
+    };
+    final Function1<ISLSet, Boolean> _function_1 = (ISLSet set) -> {
+      return Boolean.valueOf(set.copy().isSubset(top.copy()));
+    };
+    final Function1<ISLSet, ISLSet> _function_2 = (ISLSet set) -> {
+      return ISLUtil.getSpan(ISLUtil.getBasisVectors(set)).intersect(
+        ISLUtil.nullSpace(writeMaff.copy())).intersect(
+        rhoProjPreimage.copy());
+    };
+    final Function1<ISLSet, Boolean> _function_3 = (ISLSet set) -> {
+      boolean _isEmpty = set.isEmpty();
+      return Boolean.valueOf((!_isEmpty));
+    };
+    final Function1<ISLSet, ISLPoint> _function_4 = (ISLSet set) -> {
+      return set.samplePoint();
+    };
+    final Iterable<ISLPoint> edgeFlowVecs = IterableExtensions.<ISLSet, ISLPoint>map(IterableExtensions.<ISLSet>filter(IterableExtensions.<ISLSet, ISLSet>map(IterableExtensions.<ISLSet>filter(ListExtensions.<Face, ISLSet>map(lattice.getFaces((1 + nExtraDims)), _function), _function_1), _function_2), _function_3), _function_4);
+    ISLSet peak = top.copy();
+    ArrayList<ISLMap> infoFlowMaps = new ArrayList<ISLMap>();
+    for (final ISLPoint vec : edgeFlowVecs) {
+      {
+        final ISLSet accumulatedPoints = top.copy().intersect(top.copy().apply(rho.copy().toMap().reverse()));
+        boolean _isEmpty = accumulatedPoints.isEmpty();
+        boolean _not = (!_isEmpty);
+        if (_not) {
+          ISLMap _intersectDomain = ISLUtil.buildTranslationMaff(vec).toMap().intersectDomain(accumulatedPoints.copy());
+          infoFlowMaps.add(_intersectDomain);
+          peak = peak.subtract(accumulatedPoints);
+        }
+      }
+    }
+    ISLMap _intersectDomain = rho.copy().toMap().intersectDomain(basin);
+    infoFlowMaps.add(_intersectDomain);
+    CaseExpression cases = SerializeReduction.infoFlowToCases(infoFlowMaps, 
+      AlphaOperatorUtil.reductionOPtoBinaryOP(are.getOperator()), reductionVar, coreExpr);
+    EList<AlphaExpression> _exprs = cases.getExprs();
+    RestrictExpression _createRestrictExpression = AlphaUserFactory.createRestrictExpression(bottom, 
+      AlphaUtil.<AlphaExpression>copyAE(coreExpr));
+    _exprs.add(_createRestrictExpression);
+    EList<Equation> _equations = AlphaUtil.getContainerSystemBody(are).getEquations();
+    StandardEquation _createStandardEquation = AlphaUserFactory.createStandardEquation(reductionVar, cases);
+    _equations.add(_createStandardEquation);
+    EcoreUtil.replace(are, 
+      AlphaUserFactory.createReduceExpression(
+        are.getOperator(), writeMaff, 
+        AlphaUserFactory.createRestrictExpression(peak, 
+          AlphaUserFactory.createVariableExpression(reductionVar))));
+    AlphaInternalStateConstructor.recomputeContextDomain(sys);
+  }
+
+  /**
+   * Takes flow information (domains plus the Maff along which they accumulate)
+   * and turns it into dependences
+   * Because the ranges of flow maps can intersect, the number of domains one needs to consider
+   * becomes exponential wrt. dimension
+   * 
+   * O(2^d) for realistic cases
+   * O(2^(2^d)) worst case
+   */
+  private static CaseExpression infoFlowToCases(final Iterable<ISLMap> infoFlowMaps, final BINARY_OP op, final Variable v, final AlphaExpression coreExpr) {
+    final CaseExpression cases = AlphaUserFactory.createCaseExpression();
+    final Consumer<Set<ISLMap>> _function = (Set<ISLMap> wantMaps) -> {
+      final Function1<ISLMap, Boolean> _function_1 = (ISLMap map) -> {
+        boolean _contains = wantMaps.contains(map);
+        return Boolean.valueOf((!_contains));
+      };
+      final Iterable<ISLMap> unwantMaps = IterableExtensions.<ISLMap>filter(infoFlowMaps, _function_1);
+      int _size = wantMaps.size();
+      boolean _lessThan = (_size < 1);
+      if (_lessThan) {
+        return;
+      }
+      final Function1<ISLMap, ISLSet> _function_2 = (ISLMap map) -> {
+        return map.getRange();
+      };
+      final Function2<ISLSet, ISLSet, ISLSet> _function_3 = (ISLSet a, ISLSet b) -> {
+        return a.copy().intersect(b.copy());
+      };
+      ISLSet range = IterableExtensions.<ISLSet>reduce(IterableExtensions.<ISLMap, ISLSet>map(wantMaps, _function_2), _function_3);
+      boolean _isEmpty = IterableExtensions.isEmpty(unwantMaps);
+      boolean _not = (!_isEmpty);
+      if (_not) {
+        final Function1<ISLMap, ISLSet> _function_4 = (ISLMap map) -> {
+          return map.getRange();
+        };
+        final Function2<ISLSet, ISLSet, ISLSet> _function_5 = (ISLSet a, ISLSet b) -> {
+          return a.copy().union(b.copy());
+        };
+        range = range.subtract(
+          IterableExtensions.<ISLSet>reduce(IterableExtensions.<ISLMap, ISLSet>map(unwantMaps, _function_4), _function_5));
+      }
+      boolean _isEmpty_1 = range.isEmpty();
+      if (_isEmpty_1) {
+        return;
+      }
+      EList<AlphaExpression> _exprs = cases.getExprs();
+      final Function1<ISLMap, DependenceExpression> _function_6 = (ISLMap map) -> {
+        return AlphaUserFactory.createDependenceExpression(
+          ISLUtil.toMultiAff(map.copy().reverse()), 
+          AlphaUserFactory.createVariableExpression(v));
+      };
+      Iterable<DependenceExpression> _map = IterableExtensions.<ISLMap, DependenceExpression>map(wantMaps, _function_6);
+      AlphaExpression _copyAE = AlphaUtil.<AlphaExpression>copyAE(coreExpr);
+      Iterable<AlphaExpression> _plus = Iterables.<AlphaExpression>concat(_map, Collections.<AlphaExpression>unmodifiableList(CollectionLiterals.<AlphaExpression>newArrayList(_copyAE)));
+      RestrictExpression _createRestrictExpression = AlphaUserFactory.createRestrictExpression(range, 
+        AlphaUtil.createNaryExpression(op, _plus));
+      _exprs.add(_createRestrictExpression);
+    };
+    JavaUtil.<ISLMap>powerSet(IterableExtensions.<ISLMap>toSet(infoFlowMaps)).forEach(_function);
+    return cases;
   }
 
   /**

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/AlphaUtil.java
@@ -7,8 +7,10 @@ import alpha.model.AlphaPackage;
 import alpha.model.AlphaRoot;
 import alpha.model.AlphaSystem;
 import alpha.model.AlphaVisitable;
+import alpha.model.BINARY_OP;
 import alpha.model.Equation;
 import alpha.model.SystemBody;
+import alpha.model.factory.AlphaUserFactory;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import fr.irisa.cairn.jnimap.isl.ISLAff;
@@ -566,6 +568,24 @@ public class AlphaUtil {
 
   public static List<Integer> parseIntVector(final String intVecStr) {
     return IterableExtensions.<Integer>toList(((Iterable<Integer>)Conversions.doWrapArray(AlphaUtil.parseIntArray(intVecStr))));
+  }
+
+  public static AlphaExpression createNaryExpression(final BINARY_OP op, final Iterable<AlphaExpression> exprs) {
+    int _size = IterableExtensions.size(exprs);
+    boolean _lessThan = (_size < 1);
+    if (_lessThan) {
+      throw new IllegalArgumentException("exprs must be of size 1 or greater");
+    } else {
+      int _size_1 = IterableExtensions.size(exprs);
+      boolean _equals = (_size_1 == 1);
+      if (_equals) {
+        return ((AlphaExpression[])Conversions.unwrapArray(exprs, AlphaExpression.class))[0];
+      } else {
+        return AlphaUserFactory.createBinaryExpression(op, 
+          ((AlphaExpression[])Conversions.unwrapArray(exprs, AlphaExpression.class))[0], 
+          AlphaUtil.createNaryExpression(op, IterableExtensions.<AlphaExpression>toList(exprs).subList(1, IterableExtensions.size(exprs))));
+      }
+    }
   }
 
   private static Iterable<AlphaConstant> gatherAlphaConstants(final EObject ap) {

--- a/bundles/alpha.model/xtend-gen/alpha/model/util/JavaUtil.java
+++ b/bundles/alpha.model/xtend-gen/alpha/model/util/JavaUtil.java
@@ -1,0 +1,33 @@
+package alpha.model.util;
+
+import com.google.common.collect.Iterables;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+
+/**
+ * A collection of useful methods that neither Java nor Xtend had the sense to implement
+ */
+@SuppressWarnings("all")
+public class JavaUtil {
+  public static <T extends Object> Set<Set<T>> powerSet(final Collection<T> set) {
+    boolean _isEmpty = set.isEmpty();
+    if (_isEmpty) {
+      Set<T> _set = IterableExtensions.<T>toSet(Collections.<T>unmodifiableList(CollectionLiterals.<T>newArrayList()));
+      return IterableExtensions.<Set<T>>toSet(Collections.<Set<T>>unmodifiableList(CollectionLiterals.<Set<T>>newArrayList(_set)));
+    }
+    final List<T> list = IterableExtensions.<T>toList(set);
+    final T t = list.get(0);
+    final Set<Set<T>> recurseSet = JavaUtil.<T>powerSet(IterableExtensions.<T>toSet(list.subList(1, list.size())));
+    final Function1<Set<T>, Set<T>> _function = (Set<T> subset) -> {
+      List<T> _list = IterableExtensions.<T>toList(subset);
+      return IterableExtensions.<T>toSet(Iterables.<T>concat(_list, Collections.<T>unmodifiableList(CollectionLiterals.<T>newArrayList(t))));
+    };
+    Iterable<Set<T>> _map = IterableExtensions.<Set<T>, Set<T>>map(recurseSet, _function);
+    return IterableExtensions.<Set<T>>toSet(Iterables.<Set<T>>concat(_map, recurseSet));
+  }
+}

--- a/tests/alpha.model.tests/resources/src-valid/kernels/osp.alpha
+++ b/tests/alpha.model.tests/resources/src-valid/kernels/osp.alpha
@@ -1,0 +1,13 @@
+package OSP {
+	affine OSP [N] -> {:N>0}
+		inputs
+			W : {[i] : 0<=i<=N}
+		outputs
+			C : {[i,j] : 1<=i<=j<=N};
+		let
+			C[i,j] = case {
+				{: i=j} : 0[];
+				{: i<j} : reduce(min, [k], {: i<=k<j} : C[i,k] + C[k+1, j] + W[i-1]*W[j]*W[k]);
+			};
+		.
+}

--- a/tests/alpha.model.tests/src/alpha/model/tests/transformation/reduction/SerializeReductionTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/transformation/reduction/SerializeReductionTest.xtend
@@ -1,0 +1,152 @@
+package alpha.model.tests.transformation.reduction
+
+import alpha.model.AbstractReduceExpression
+import alpha.model.AlphaModelLoader
+import alpha.model.AlphaSystem
+import alpha.model.AlphaVisitable
+import alpha.model.DependenceExpression
+import alpha.model.ReduceExpression
+import alpha.model.StandardEquation
+import alpha.model.UniquenessAndCompletenessCheck
+import alpha.model.Variable
+import alpha.model.VariableExpression
+import alpha.model.transformation.Normalize
+import alpha.model.transformation.reduction.NormalizeReduction
+import alpha.model.transformation.reduction.SerializeReduction
+import alpha.model.util.AbstractAlphaCompleteVisitor
+import fr.irisa.cairn.jnimap.isl.ISLDimType
+import fr.irisa.cairn.jnimap.isl.ISLSet
+import fr.irisa.cairn.jnimap.isl.ISLUnionSet
+import java.util.Set
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+import static extension alpha.model.util.AlphaUtil.*
+
+class SerializeReductionTest {
+	protected static class ReadSetComputer extends AbstractAlphaCompleteVisitor {
+		protected var ISLUnionSet readUSet
+		
+		new() {
+			readUSet = null
+		}
+		
+		def static compute(AlphaVisitable an) {
+			val comp = new ReadSetComputer()
+			an.accept(comp)
+			return comp.readUSet
+		}
+		
+		override outDependenceExpression(DependenceExpression de) {
+			val readSet = de.getContextDomain.copy.apply(de.getFunction.copy.toMap)
+				.setTupleName((de.expr as VariableExpression).variable.name).toUnionSet
+				
+			if(readUSet === null) readUSet = readSet
+			else readUSet = readUSet.union(readSet)
+		}
+	}
+	
+	protected static class ReductionBoundednessChecker extends AbstractAlphaCompleteVisitor {
+		def static apply(AlphaVisitable an) {
+			val comp = new ReductionBoundednessChecker()
+			an.accept(comp)
+		}
+		
+		override outReduceExpression(ReduceExpression are) {
+			val domain = are.body.getContextDomain.copy()
+			(0..domain.dim(ISLDimType.isl_dim_set)-1).forEach[ i | 
+				assertTrue(domain.hasUpperBound(ISLDimType.isl_dim_set, i))
+				assertTrue(domain.hasLowerBound(ISLDimType.isl_dim_set, i))
+			]
+		}
+	}
+	
+	var AlphaSystem sys
+	
+	def void readFileAndSerialize(String file) {
+		sys = AlphaModelLoader.loadModel(file).systems.get(0)
+		val Set<String> variableNames = sys.getVariables.map[variable | variable.name].toSet
+		
+		NormalizeReduction.apply(sys)
+		val Iterable<Variable> reductionVariables = sys.getVariables.filter[variable | !variableNames.contains(variable.name)]
+		
+		for(v : reductionVariables) {
+			autoSerializeAndAssert(v.getStandardEquation.getExpr as AbstractReduceExpression)
+		}
+	}
+	
+	def void autoSerializeAndAssert(AbstractReduceExpression are) {
+		val ISLSet originalDomain = are.body.getContextDomain.copy 
+		val ISLUnionSet originalReadSet = ReadSetComputer.compute(are.getContainerEquation)
+		
+		val Variable writeVar = (are.getContainerEquation as StandardEquation).variable
+		val Set<String> variableNames = sys.getVariables.map[variable | variable.name].toSet
+		
+		SerializeReduction.applyAuto(are)
+		Normalize.apply(sys)
+		
+		val Variable newVariable = sys.getVariables.findFirst[variable | !variableNames.contains(variable.name)]
+		
+		val StandardEquation writeSE = writeVar.getStandardEquation
+		val StandardEquation newSE = newVariable.getStandardEquation
+		
+		assertReductionDomainUnchanged(originalDomain, newSE)
+		assertReadSetUnchanged(originalReadSet, newSE)
+		assertAllPointsReduced(originalDomain, newSE, writeSE)
+		assertAllReductionsBounded
+		assertUniqueAndComplete
+	}
+	
+	def assertReductionDomainUnchanged(ISLSet originalDomain, StandardEquation newSE) {
+		assertTrue(originalDomain.copy.isPlainEqual(newSE.expr.contextDomain.copy))
+	}
+	
+	def assertReadSetUnchanged(ISLUnionSet originalReadSet, StandardEquation newSE) {
+		val readUSet = ReadSetComputer.compute(newSE).coalesce
+		
+		assertTrue(originalReadSet.copy.isSubset(readUSet.copy))
+		readUSet.copy.getSets.filter[ set | set.getTupleName != newSE.variable.name].forEach[ set | 
+			assertTrue(set.copy.toUnionSet.isSubset(originalReadSet.copy))
+		]
+	}
+	
+	def assertAllPointsReduced(ISLSet originalDomain, StandardEquation newSE, StandardEquation writeSE) {
+		val resultSet = ReadSetComputer.compute(writeSE).getSets
+			.findFirst[ set | set.getTupleName == newSE.variable.name]
+			
+		val nonResultSet = ReadSetComputer.compute(newSE).getSets
+			.findFirst[ set | set.getTupleName == newSE.variable.name]
+			
+		val totalSet = resultSet.union(nonResultSet)
+		assertTrue(originalDomain.isPlainEqual(totalSet.coalesce.clearTupleName))
+	}
+	
+	def assertAllReductionsBounded() {
+		ReductionBoundednessChecker.apply(sys)
+	}
+	
+	def assertUniqueAndComplete() {
+		assertTrue(UniquenessAndCompletenessCheck.check(sys.getContainerRoot).isEmpty)
+	}
+	
+	def StandardEquation getStandardEquation(Variable v) {
+		sys.systemBodies.map[ body | body.getStandardEquation(v)]
+			.findFirst[ se | se !== null]
+	}
+	
+	@Test
+	def void testOSP() {
+		readFileAndSerialize("resources/src-valid/kernels/osp.alpha")
+	} 
+	
+	@Test
+	def void testBPMax() {
+		readFileAndSerialize("resources/src-valid/kernels/bpmax.alpha")
+	}
+	
+	@Test
+	def void testCholesky() {
+		readFileAndSerialize("resources/src-valid/kernels/cholesky.alpha")
+	}
+}

--- a/tests/alpha.model.tests/src/alpha/model/tests/transformation/reduction/SerializeReductionTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/transformation/reduction/SerializeReductionTest.xtend
@@ -64,26 +64,33 @@ class SerializeReductionTest {
 	
 	var AlphaSystem sys
 	
-	def void readFileAndSerialize(String file) {
+	def void readFileAndSerialize(String file, boolean oneShot) {
 		sys = AlphaModelLoader.loadModel(file).systems.get(0)
-		val Set<String> variableNames = sys.getVariables.map[variable | variable.name].toSet
 		
 		NormalizeReduction.apply(sys)
-		val Iterable<Variable> reductionVariables = sys.getVariables.filter[variable | !variableNames.contains(variable.name)]
+		val Iterable<Variable> reductionVariables = sys.getVariables.filter[variable |
+			val standardEq = sys.systemBodies.get(0).getStandardEquation(variable)
+			if(standardEq === null) return false;
+			return standardEq.expr instanceof ReduceExpression
+		]
 		
 		for(v : reductionVariables) {
-			autoSerializeAndAssert(v.getStandardEquation.getExpr as AbstractReduceExpression)
+			autoSerializeAndAssert(v.getStandardEquation.getExpr as AbstractReduceExpression, oneShot)
 		}
 	}
 	
-	def void autoSerializeAndAssert(AbstractReduceExpression are) {
+	def void autoSerializeAndAssert(AbstractReduceExpression are, boolean oneShot) {
 		val ISLSet originalDomain = are.body.getContextDomain.copy 
 		val ISLUnionSet originalReadSet = ReadSetComputer.compute(are.getContainerEquation)
 		
 		val Variable writeVar = (are.getContainerEquation as StandardEquation).variable
 		val Set<String> variableNames = sys.getVariables.map[variable | variable.name].toSet
 		
-		SerializeReduction.applyAuto(are)
+		if(oneShot){
+			SerializeReduction.applyAuto(are, true)
+		} else {
+			SerializeReduction.applyAuto(are)
+		}
 		Normalize.apply(sys)
 		
 		val Variable newVariable = sys.getVariables.findFirst[variable | !variableNames.contains(variable.name)]
@@ -137,16 +144,7 @@ class SerializeReductionTest {
 	
 	@Test
 	def void testOSP() {
-		readFileAndSerialize("resources/src-valid/kernels/osp.alpha")
+		readFileAndSerialize("resources/src-valid/kernels/osp.alpha", false)
+		readFileAndSerialize("resources/src-valid/kernels/osp.alpha", true)
 	} 
-	
-	@Test
-	def void testBPMax() {
-		readFileAndSerialize("resources/src-valid/kernels/bpmax.alpha")
-	}
-	
-	@Test
-	def void testCholesky() {
-		readFileAndSerialize("resources/src-valid/kernels/cholesky.alpha")
-	}
 }

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/SerializeReductionTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/SerializeReductionTest.java
@@ -1,0 +1,197 @@
+package alpha.model.tests.transformation.reduction;
+
+import alpha.model.AbstractReduceExpression;
+import alpha.model.AlphaExpression;
+import alpha.model.AlphaModelLoader;
+import alpha.model.AlphaSystem;
+import alpha.model.AlphaVisitable;
+import alpha.model.DependenceExpression;
+import alpha.model.Equation;
+import alpha.model.ReduceExpression;
+import alpha.model.StandardEquation;
+import alpha.model.SystemBody;
+import alpha.model.UniquenessAndCompletenessCheck;
+import alpha.model.Variable;
+import alpha.model.VariableExpression;
+import alpha.model.transformation.Normalize;
+import alpha.model.transformation.reduction.NormalizeReduction;
+import alpha.model.transformation.reduction.SerializeReduction;
+import alpha.model.util.AbstractAlphaCompleteVisitor;
+import alpha.model.util.AlphaUtil;
+import com.google.common.base.Objects;
+import fr.irisa.cairn.jnimap.isl.ISLDimType;
+import fr.irisa.cairn.jnimap.isl.ISLSet;
+import fr.irisa.cairn.jnimap.isl.ISLUnionSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IntegerRange;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class SerializeReductionTest {
+  protected static class ReadSetComputer extends AbstractAlphaCompleteVisitor {
+    protected ISLUnionSet readUSet;
+
+    public ReadSetComputer() {
+      this.readUSet = null;
+    }
+
+    public static ISLUnionSet compute(final AlphaVisitable an) {
+      final SerializeReductionTest.ReadSetComputer comp = new SerializeReductionTest.ReadSetComputer();
+      an.accept(comp);
+      return comp.readUSet;
+    }
+
+    @Override
+    public void outDependenceExpression(final DependenceExpression de) {
+      AlphaExpression _expr = de.getExpr();
+      final ISLUnionSet readSet = de.getContextDomain().copy().apply(de.getFunction().copy().toMap()).setTupleName(((VariableExpression) _expr).getVariable().getName()).toUnionSet();
+      if ((this.readUSet == null)) {
+        this.readUSet = readSet;
+      } else {
+        this.readUSet = this.readUSet.union(readSet);
+      }
+    }
+  }
+
+  protected static class ReductionBoundednessChecker extends AbstractAlphaCompleteVisitor {
+    public static void apply(final AlphaVisitable an) {
+      final SerializeReductionTest.ReductionBoundednessChecker comp = new SerializeReductionTest.ReductionBoundednessChecker();
+      an.accept(comp);
+    }
+
+    @Override
+    public void outReduceExpression(final ReduceExpression are) {
+      final ISLSet domain = are.getBody().getContextDomain().copy();
+      int _dim = domain.dim(ISLDimType.isl_dim_set);
+      int _minus = (_dim - 1);
+      final Consumer<Integer> _function = (Integer i) -> {
+        Assert.assertTrue(domain.hasUpperBound(ISLDimType.isl_dim_set, (i).intValue()));
+        Assert.assertTrue(domain.hasLowerBound(ISLDimType.isl_dim_set, (i).intValue()));
+      };
+      new IntegerRange(0, _minus).forEach(_function);
+    }
+  }
+
+  private AlphaSystem sys;
+
+  public void readFileAndSerialize(final String file) {
+    try {
+      this.sys = AlphaModelLoader.loadModel(file).getSystems().get(0);
+      final Function1<Variable, String> _function = (Variable variable) -> {
+        return variable.getName();
+      };
+      final Set<String> variableNames = IterableExtensions.<String>toSet(ListExtensions.<Variable, String>map(this.sys.getVariables(), _function));
+      NormalizeReduction.apply(this.sys);
+      final Function1<Variable, Boolean> _function_1 = (Variable variable) -> {
+        boolean _contains = variableNames.contains(variable.getName());
+        return Boolean.valueOf((!_contains));
+      };
+      final Iterable<Variable> reductionVariables = IterableExtensions.<Variable>filter(this.sys.getVariables(), _function_1);
+      for (final Variable v : reductionVariables) {
+        AlphaExpression _expr = this.getStandardEquation(v).getExpr();
+        this.autoSerializeAndAssert(((AbstractReduceExpression) _expr));
+      }
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+
+  public void autoSerializeAndAssert(final AbstractReduceExpression are) {
+    final ISLSet originalDomain = are.getBody().getContextDomain().copy();
+    final ISLUnionSet originalReadSet = SerializeReductionTest.ReadSetComputer.compute(AlphaUtil.getContainerEquation(are));
+    Equation _containerEquation = AlphaUtil.getContainerEquation(are);
+    final Variable writeVar = ((StandardEquation) _containerEquation).getVariable();
+    final Function1<Variable, String> _function = (Variable variable) -> {
+      return variable.getName();
+    };
+    final Set<String> variableNames = IterableExtensions.<String>toSet(ListExtensions.<Variable, String>map(this.sys.getVariables(), _function));
+    SerializeReduction.applyAuto(are);
+    Normalize.apply(this.sys);
+    final Function1<Variable, Boolean> _function_1 = (Variable variable) -> {
+      boolean _contains = variableNames.contains(variable.getName());
+      return Boolean.valueOf((!_contains));
+    };
+    final Variable newVariable = IterableExtensions.<Variable>findFirst(this.sys.getVariables(), _function_1);
+    final StandardEquation writeSE = this.getStandardEquation(writeVar);
+    final StandardEquation newSE = this.getStandardEquation(newVariable);
+    this.assertReductionDomainUnchanged(originalDomain, newSE);
+    this.assertReadSetUnchanged(originalReadSet, newSE);
+    this.assertAllPointsReduced(originalDomain, newSE, writeSE);
+    this.assertAllReductionsBounded();
+    this.assertUniqueAndComplete();
+  }
+
+  public void assertReductionDomainUnchanged(final ISLSet originalDomain, final StandardEquation newSE) {
+    Assert.assertTrue(originalDomain.copy().isPlainEqual(newSE.getExpr().getContextDomain().copy()));
+  }
+
+  public void assertReadSetUnchanged(final ISLUnionSet originalReadSet, final StandardEquation newSE) {
+    final ISLUnionSet readUSet = SerializeReductionTest.ReadSetComputer.compute(newSE).coalesce();
+    Assert.assertTrue(originalReadSet.copy().isSubset(readUSet.copy()));
+    final Function1<ISLSet, Boolean> _function = (ISLSet set) -> {
+      String _tupleName = set.getTupleName();
+      String _name = newSE.getVariable().getName();
+      return Boolean.valueOf((!Objects.equal(_tupleName, _name)));
+    };
+    final Consumer<ISLSet> _function_1 = (ISLSet set) -> {
+      Assert.assertTrue(set.copy().toUnionSet().isSubset(originalReadSet.copy()));
+    };
+    IterableExtensions.<ISLSet>filter(readUSet.copy().getSets(), _function).forEach(_function_1);
+  }
+
+  public void assertAllPointsReduced(final ISLSet originalDomain, final StandardEquation newSE, final StandardEquation writeSE) {
+    final Function1<ISLSet, Boolean> _function = (ISLSet set) -> {
+      String _tupleName = set.getTupleName();
+      String _name = newSE.getVariable().getName();
+      return Boolean.valueOf(Objects.equal(_tupleName, _name));
+    };
+    final ISLSet resultSet = IterableExtensions.<ISLSet>findFirst(SerializeReductionTest.ReadSetComputer.compute(writeSE).getSets(), _function);
+    final Function1<ISLSet, Boolean> _function_1 = (ISLSet set) -> {
+      String _tupleName = set.getTupleName();
+      String _name = newSE.getVariable().getName();
+      return Boolean.valueOf(Objects.equal(_tupleName, _name));
+    };
+    final ISLSet nonResultSet = IterableExtensions.<ISLSet>findFirst(SerializeReductionTest.ReadSetComputer.compute(newSE).getSets(), _function_1);
+    final ISLSet totalSet = resultSet.union(nonResultSet);
+    Assert.assertTrue(originalDomain.isPlainEqual(totalSet.coalesce().clearTupleName()));
+  }
+
+  public void assertAllReductionsBounded() {
+    SerializeReductionTest.ReductionBoundednessChecker.apply(this.sys);
+  }
+
+  public void assertUniqueAndComplete() {
+    Assert.assertTrue(UniquenessAndCompletenessCheck.check(AlphaUtil.getContainerRoot(this.sys)).isEmpty());
+  }
+
+  public StandardEquation getStandardEquation(final Variable v) {
+    final Function1<SystemBody, StandardEquation> _function = (SystemBody body) -> {
+      return body.getStandardEquation(v);
+    };
+    final Function1<StandardEquation, Boolean> _function_1 = (StandardEquation se) -> {
+      return Boolean.valueOf((se != null));
+    };
+    return IterableExtensions.<StandardEquation>findFirst(ListExtensions.<SystemBody, StandardEquation>map(this.sys.getSystemBodies(), _function), _function_1);
+  }
+
+  @Test
+  public void testOSP() {
+    this.readFileAndSerialize("resources/src-valid/kernels/osp.alpha");
+  }
+
+  @Test
+  public void testBPMax() {
+    this.readFileAndSerialize("resources/src-valid/kernels/bpmax.alpha");
+  }
+
+  @Test
+  public void testCholesky() {
+    this.readFileAndSerialize("resources/src-valid/kernels/cholesky.alpha");
+  }
+}

--- a/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/SerializeReductionTest.java
+++ b/tests/alpha.model.tests/xtend-gen/alpha/model/tests/transformation/reduction/SerializeReductionTest.java
@@ -80,29 +80,29 @@ public class SerializeReductionTest {
 
   private AlphaSystem sys;
 
-  public void readFileAndSerialize(final String file) {
+  public void readFileAndSerialize(final String file, final boolean oneShot) {
     try {
       this.sys = AlphaModelLoader.loadModel(file).getSystems().get(0);
-      final Function1<Variable, String> _function = (Variable variable) -> {
-        return variable.getName();
-      };
-      final Set<String> variableNames = IterableExtensions.<String>toSet(ListExtensions.<Variable, String>map(this.sys.getVariables(), _function));
       NormalizeReduction.apply(this.sys);
-      final Function1<Variable, Boolean> _function_1 = (Variable variable) -> {
-        boolean _contains = variableNames.contains(variable.getName());
-        return Boolean.valueOf((!_contains));
+      final Function1<Variable, Boolean> _function = (Variable variable) -> {
+        final StandardEquation standardEq = this.sys.getSystemBodies().get(0).getStandardEquation(variable);
+        if ((standardEq == null)) {
+          return Boolean.valueOf(false);
+        }
+        AlphaExpression _expr = standardEq.getExpr();
+        return Boolean.valueOf((_expr instanceof ReduceExpression));
       };
-      final Iterable<Variable> reductionVariables = IterableExtensions.<Variable>filter(this.sys.getVariables(), _function_1);
+      final Iterable<Variable> reductionVariables = IterableExtensions.<Variable>filter(this.sys.getVariables(), _function);
       for (final Variable v : reductionVariables) {
         AlphaExpression _expr = this.getStandardEquation(v).getExpr();
-        this.autoSerializeAndAssert(((AbstractReduceExpression) _expr));
+        this.autoSerializeAndAssert(((AbstractReduceExpression) _expr), oneShot);
       }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
   }
 
-  public void autoSerializeAndAssert(final AbstractReduceExpression are) {
+  public void autoSerializeAndAssert(final AbstractReduceExpression are, final boolean oneShot) {
     final ISLSet originalDomain = are.getBody().getContextDomain().copy();
     final ISLUnionSet originalReadSet = SerializeReductionTest.ReadSetComputer.compute(AlphaUtil.getContainerEquation(are));
     Equation _containerEquation = AlphaUtil.getContainerEquation(are);
@@ -111,7 +111,11 @@ public class SerializeReductionTest {
       return variable.getName();
     };
     final Set<String> variableNames = IterableExtensions.<String>toSet(ListExtensions.<Variable, String>map(this.sys.getVariables(), _function));
-    SerializeReduction.applyAuto(are);
+    if (oneShot) {
+      SerializeReduction.applyAuto(are, true);
+    } else {
+      SerializeReduction.applyAuto(are);
+    }
     Normalize.apply(this.sys);
     final Function1<Variable, Boolean> _function_1 = (Variable variable) -> {
       boolean _contains = variableNames.contains(variable.getName());
@@ -182,16 +186,7 @@ public class SerializeReductionTest {
 
   @Test
   public void testOSP() {
-    this.readFileAndSerialize("resources/src-valid/kernels/osp.alpha");
-  }
-
-  @Test
-  public void testBPMax() {
-    this.readFileAndSerialize("resources/src-valid/kernels/bpmax.alpha");
-  }
-
-  @Test
-  public void testCholesky() {
-    this.readFileAndSerialize("resources/src-valid/kernels/cholesky.alpha");
+    this.readFileAndSerialize("resources/src-valid/kernels/osp.alpha", false);
+    this.readFileAndSerialize("resources/src-valid/kernels/osp.alpha", true);
   }
 }


### PR DESCRIPTION
Closes #130 
Closes #126 
because the most sane way to schedule or tile a reduction is to serialize it first.