### PR TITLE
Adds the PolyLibUtil.extend and associated tests

### DIFF
--- a/bundles/alpha.model/src/alpha/model/util/PolyLibUtil.xtend
+++ b/bundles/alpha.model/src/alpha/model/util/PolyLibUtil.xtend
@@ -1,0 +1,137 @@
+package alpha.model.util
+
+import fr.irisa.cairn.jnimap.isl.ISLSet
+import fr.irisa.cairn.jnimap.polylib.PolyLibPolyhedron
+import fr.irisa.cairn.jnimap.isl.ISLSpace
+import java.util.ArrayList
+import java.util.List
+import fr.irisa.cairn.jnimap.isl.ISLConstraint
+import fr.irisa.cairn.jnimap.isl.ISLDimType
+
+import static alpha.model.util.AffineFunctionOperations.*
+import static alpha.model.util.ISLUtil.*
+import fr.irisa.cairn.jnimap.polylib.PolyLibMatrix
+import fr.irisa.cairn.jnimap.isl.ISLMap
+
+class PolyLibUtil {
+	
+   	/**
+	 * Takes a PolyLibMatrix and a corresponding ISLSpace
+	 * and builds an ISLSet of that Matrix in that space
+	 * Treating each row as a constraint as defined
+	 * in the PolyLib Documentation
+	 * 
+	 * @param poly
+	 * @param setSpace
+	 * @return 
+	 */
+    static def ISLSet toISLSet(PolyLibMatrix matrix, ISLSpace setSpace) {
+    	val List<ISLConstraint> constraints = new ArrayList()
+    	for(var constraint = 0; constraint < matrix.nbRows; constraint++) {
+    		var ISLConstraint islConstraint
+    		if(matrix.getAt(constraint, 0) == 0) {
+    			islConstraint = ISLConstraint.buildEquality(setSpace.copy)
+    		} else {
+    			islConstraint = ISLConstraint.buildInequality(setSpace.copy) 
+    		}
+    		for(var col = 1; col < matrix.nbColumns - 1; col++) {
+    			if(col - 1 >= setSpace.nbOutputs) {
+    				islConstraint = islConstraint.setCoefficient(ISLDimType.isl_dim_param, col - setSpace.nbOutputs - 1, matrix.getAt(constraint.intValue, col).intValue)
+    			} else {
+    				islConstraint = islConstraint.setCoefficient(ISLDimType.isl_dim_out, col - 1, matrix.getAt(constraint.intValue, col).intValue)
+    			}
+    		}
+    		islConstraint = islConstraint.setConstant(matrix.getAt(constraint, matrix.nbColumns - 1))
+    		constraints.add(islConstraint)
+    	}
+    	constraints.fold(ISLSet.buildUniverse(setSpace), [acc, constraint | acc.addConstraint(constraint)])    
+    }
+    
+   	/**
+	 * Takes a PolyLibPolyhedron and a corresponding ISLSpace
+	 * and builds an ISLSet of that polyhedron in that space
+	 * 
+	 * @param poly
+	 * @param setSpace
+	 * @return 
+	 */
+	static def ISLSet toISLSet(PolyLibPolyhedron poly, ISLSpace setSpace) {
+    	var PolyLibMatrix m = PolyLibMatrix.buildFromConstraints(poly);
+    	toISLSet(m, setSpace)
+    }
+    
+	/**
+	 * Converts ISLMap into PolyLibMatrix. The matrix is [A|b] of the
+	 * Ax + b representation of the function. 
+	 * 
+	 * @param map
+	 * @return 
+	 */
+	static def PolyLibMatrix toPolyLibMatrix(ISLMap map) {
+		val maff = toMultiAff(map.copy)
+		val int nbParam = map.nbParams
+		val int nbIndices = map.nbInputs
+
+		var output = PolyLibMatrix.allocate(map.nbOutputs, map.nbInputs + map.nbParams + 1)
+						
+		for (var row = 0; row < maff.affs.size; row++) {
+			val aff = maff.affs.get(row)
+			//Only handles affine
+			if (aff.getDenominator() != 1) throw new RuntimeException("Quasi-Affine Functions are not handled");
+			if (aff.dim(ISLDimType.isl_dim_div) > 0) throw new RuntimeException("Quasi-Affine Functions are not handled");
+
+			// indices first
+			for (var i = 0; i < nbIndices; i++) {
+				output.setAt(row, i, aff.getCoefficientVal(ISLDimType.isl_dim_in, i).asLong)
+			}
+
+			// parameters next
+			for (var pi = 0; pi < nbParam; pi++) {
+				output.setAt(row, nbIndices + pi, aff.getCoefficientVal(ISLDimType.isl_dim_param, pi).asLong)
+			}
+
+			// constant
+			output.setAt(row, nbIndices + nbParam, aff.getConstantVal().asLong())		
+		}
+		
+		output
+	}
+	
+	/**
+	 * Converts PolyLibPolyhedron into its dual space as an ISLSet (in the space setSpace).
+	 * This function ignores the params and just builds the space with the indices 
+	 * (you will have to manipulate the space yourself to get the params back in
+	 * 
+	 * @param poly
+	 * @param setSpace
+	 * @return 
+	 */
+	static def ISLSet toDualISLSet(PolyLibPolyhedron poly, ISLSpace setSpace) {
+    	val rays = poly.builRaysVertices
+	  	val List<ISLConstraint> constraints = new ArrayList()
+	  	  
+    	for(var ray = 0; ray < rays.nbRows; ray++) {
+    		for(var col = 0; col < rays.nbColumns; col++) {
+    				print(rays.getAt(ray, col) + " ")
+    		}
+    		println()
+    	}
+    	for(var ray = 0; ray < rays.nbRows; ray++) {
+    		var ISLConstraint islConstraint = ISLConstraint.buildInequality(setSpace.copy) 
+
+    		if(rays.getAt(ray, 0) == 1 && rays.getAt(ray, rays.nbColumns - 1) == 0) {
+    			for(var col = 1; col < rays.nbColumns - 1; col++) {
+    				print(rays.getAt(ray, col) + " ")
+	    			if(!(col - 1 >= setSpace.nbOutputs)) {
+	    				islConstraint = islConstraint.setCoefficient(ISLDimType.isl_dim_out, col - 1, rays.getAt(ray, col).intValue)
+	    			}
+    			}
+    		}
+    		println()
+    		println(islConstraint)
+    		constraints.add(islConstraint)
+    	}
+    	constraints.fold(ISLSet.buildUniverse(setSpace.copy), [acc, constraint | acc.addConstraint(constraint)]).simplify
+    } 
+    
+}

--- a/tests/alpha.model.tests/src/alpha/model/tests/util/PolyLibUtilTest.xtend
+++ b/tests/alpha.model.tests/src/alpha/model/tests/util/PolyLibUtilTest.xtend
@@ -1,0 +1,98 @@
+package alpha.model.tests.util
+
+import fr.irisa.cairn.jnimap.isl.ISLSet
+import fr.irisa.cairn.jnimap.polylib.PolyLibPolyhedron
+import org.junit.Test
+
+import static alpha.model.util.ISLUtil.*
+import static alpha.model.util.PolyLibUtil.*
+import static org.junit.Assert.*
+import fr.irisa.cairn.jnimap.polylib.PolyLibMatrix
+import fr.irisa.cairn.jnimap.isl.ISLMap
+
+class PolyLibUtilTest {
+	
+	/*
+	 * Helper Function(s)
+	 */
+	static def boolean isEqual(PolyLibMatrix m1, PolyLibMatrix m2) {
+    	if(m1.nbColumns != m2.nbColumns) return false
+    	else if(m1.nbRows != m2.nbRows) return false
+    	else {
+    		for(var i = 0; i < m1.nbRows; i++) {
+    			for(var j = 0; j < m1.nbColumns; j++) {
+    				if(m1.getAt(i, j) != m2.getAt(i, j)) { 
+    					return false
+    				}
+    			}
+    		}
+    	}	
+    	true
+    }
+	
+	/*
+	 * Tests
+	 */
+	 
+	 @Test
+	def testPolyLibMatrixToISLSetOne() {
+    	val ISLSet set = toISLSet("[N] -> {[i, j] : 0 <= i <= N and 0 <= j <= i}")
+    	val PolyLibPolyhedron polyhedron = PolyLibPolyhedron.createFromLongMatrix(set.copy.getBasicSetAt(0).toPolyLibArray)
+    	val output = toISLSet(PolyLibMatrix.buildFromConstraints(polyhedron), set.space)
+		assertTrue(set.copy.isEqual(output))
+    }
+    
+    @Test
+   	def testPolyLibPolyhedronToISLSetOne() {
+    	val ISLSet set = toISLSet("[N] -> {[i, j] : 0 <= i <= N and 0 <= j <= i}")
+    	val PolyLibPolyhedron polyhedron = PolyLibPolyhedron.createFromLongMatrix(set.copy.getBasicSetAt(0).toPolyLibArray)
+    	val output = toISLSet(polyhedron, set.space)
+		assertTrue(set.copy.isEqual(output))
+    }
+     
+    @Test
+    def testISLMapToPolyLibMatrixOne() {
+    	val ISLMap map = toISLMap("{[i, j] -> [i, j]}")
+    	val PolyLibMatrix expected = PolyLibMatrix.allocate(2, 3)
+    	
+    	expected.setAt(0, 0, 1)
+    	expected.setAt(1, 1, 1)
+    	
+    	assertTrue(expected.isEqual(toPolyLibMatrix(map)))
+    }
+    
+    @Test
+    def testISLMapToPolyLibMatrixTwo() {
+    	val ISLMap map = toISLMap("[N] -> {[i, j] -> [i + 2 * j + 1, N - j]}")
+    	val PolyLibMatrix expected = PolyLibMatrix.allocate(2, 4)
+
+    	expected.setAt(0, 0, 1)
+    	expected.setAt(0, 1, 2)
+    	expected.setAt(0, 3, 1)
+    	expected.setAt(1, 1, -1)
+    	expected.setAt(1, 2, 1)
+    	
+    	assertTrue(expected.isEqual(toPolyLibMatrix(map)))
+    }
+
+    //The set and it's dual should be the same
+    @Test 
+	def testRaysToDualSetOne() {
+    	val ISLSet set = toISLSet("[N] -> {[i, j] : 0 <= i}")
+    	val PolyLibPolyhedron polyhedron = PolyLibPolyhedron.createFromLongMatrix(set.copy.getBasicSetAt(0).toPolyLibArray)
+    	val output = toDualISLSet(polyhedron, set.space)
+    	println(output.copy)
+		assertTrue(set.copy.isEqual(output))
+    }
+    
+        
+	@Test 
+	def testRaysToDualSetTwo() {
+    	val ISLSet set = toISLSet("[N] -> {[i, j] : 0 <= i <= N and i <= j <= 2 * i}")
+    	val ISLSet correctOutput = toISLSet("[N] -> {[i, j] : -i <= j and -i <= 2 * j}")
+    	val PolyLibPolyhedron polyhedron = PolyLibPolyhedron.createFromLongMatrix(set.copy.getBasicSetAt(0).toPolyLibArray)
+    	val output = toDualISLSet(polyhedron, set.space)
+		assertTrue(correctOutput.copy.isEqual(output))
+    }
+    
+}


### PR DESCRIPTION
This creates some helper functions for PolyLib objects mostly related to their translation back and forth between ISL, as well as the construction of the dual cone for a set of rays. This is an initial step in resolving (https://github.com/CSU-CS-Melange/alpha-language/issues/135)